### PR TITLE
Fix demo bugs + advanced matching, top-up, settlement, lender prefs, analytics

### DIFF
--- a/apps/web/src/app/(app)/data/page.tsx
+++ b/apps/web/src/app/(app)/data/page.tsx
@@ -1,0 +1,180 @@
+import { createClient } from "@/lib/supabase/server";
+import { TopBar } from "@/components/layout/top-bar";
+
+export default async function DataPage() {
+  const supabase = await createClient();
+
+  // Fetch aggregate analytics from views
+  const [
+    { data: tradeAnalytics },
+    { data: riskDist },
+    { data: poolOverview },
+  ] = await Promise.all([
+    supabase.from("trade_analytics").select("*"),
+    supabase.from("risk_distribution").select("*"),
+    supabase.from("pool_overview").select("*").single(),
+  ]);
+
+  // Compute summary stats
+  const totalTrades = tradeAnalytics?.reduce((s, r) => s + Number(r.trade_count), 0) ?? 0;
+  const totalVolume = tradeAnalytics?.reduce((s, r) => s + Number(r.total_volume ?? 0), 0) ?? 0;
+  const totalFees = tradeAnalytics?.reduce((s, r) => s + Number(r.total_fees ?? 0), 0) ?? 0;
+
+  const poolSize = Number(poolOverview?.total_pool_size ?? 0);
+  const poolAvailable = Number(poolOverview?.total_available ?? 0);
+  const poolLocked = Number(poolOverview?.total_locked ?? 0);
+  const lenderCount = Number(poolOverview?.lender_count ?? 0);
+
+  const fmt = (gbp: number) => "\u00A3" + gbp.toFixed(2);
+
+  return (
+    <div>
+      <TopBar title="Data & Analytics" />
+      <div className="px-4 py-6 space-y-6 max-w-2xl mx-auto">
+        {/* Pool Summary */}
+        <section className="card-monzo p-5 space-y-3">
+          <h2 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+            Pool Summary
+          </h2>
+          <div className="grid grid-cols-2 gap-4">
+            <StatCard label="Pool Size" value={fmt(poolSize)} />
+            <StatCard label="Available" value={fmt(poolAvailable)} />
+            <StatCard label="Locked" value={fmt(poolLocked)} />
+            <StatCard label="Lenders" value={String(lenderCount)} />
+          </div>
+        </section>
+
+        {/* Trade Summary */}
+        <section className="card-monzo p-5 space-y-3">
+          <h2 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+            Trade Summary
+          </h2>
+          <div className="grid grid-cols-3 gap-4">
+            <StatCard label="Total Trades" value={String(totalTrades)} />
+            <StatCard label="Volume" value={fmt(totalVolume)} />
+            <StatCard label="Fees" value={fmt(totalFees)} />
+          </div>
+        </section>
+
+        {/* Trade Analytics by Grade */}
+        <section className="card-monzo p-5 space-y-3">
+          <h2 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+            Trade Analytics by Grade
+          </h2>
+          {tradeAnalytics && tradeAnalytics.length > 0 ? (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-left text-text-muted text-xs border-b border-warm-grey">
+                    <th className="py-2 pr-3">Grade</th>
+                    <th className="py-2 pr-3">Status</th>
+                    <th className="py-2 pr-3 text-right">Count</th>
+                    <th className="py-2 pr-3 text-right">Avg Amount</th>
+                    <th className="py-2 pr-3 text-right">Avg Fee</th>
+                    <th className="py-2 text-right">Default Rate</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {tradeAnalytics.map((row, i) => (
+                    <tr key={i} className="border-b border-warm-grey/50 last:border-0">
+                      <td className="py-2 pr-3">
+                        <span
+                          className={`inline-flex items-center justify-center w-6 h-6 rounded-full text-xs font-bold ${
+                            row.risk_grade === "A"
+                              ? "bg-success/15 text-success"
+                              : row.risk_grade === "B"
+                                ? "bg-warning/15 text-warning"
+                                : "bg-danger/15 text-danger"
+                          }`}
+                        >
+                          {row.risk_grade}
+                        </span>
+                      </td>
+                      <td className="py-2 pr-3 text-navy">{row.status}</td>
+                      <td className="py-2 pr-3 text-right font-medium">{row.trade_count}</td>
+                      <td className="py-2 pr-3 text-right">{fmt(Number(row.avg_amount))}</td>
+                      <td className="py-2 pr-3 text-right">{fmt(Number(row.avg_fee))}</td>
+                      <td className="py-2 text-right">
+                        {row.default_rate != null
+                          ? `${(Number(row.default_rate) * 100).toFixed(1)}%`
+                          : "—"}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          ) : (
+            <p className="text-sm text-text-secondary">No trade data yet.</p>
+          )}
+        </section>
+
+        {/* Risk Distribution */}
+        <section className="card-monzo p-5 space-y-3">
+          <h2 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+            Risk Distribution
+          </h2>
+          {riskDist && riskDist.length > 0 ? (
+            <div className="flex gap-3">
+              {riskDist.map((row) => (
+                <div
+                  key={row.risk_grade}
+                  className={`flex-1 text-center py-3 rounded-xl ${
+                    row.risk_grade === "A"
+                      ? "bg-success/10"
+                      : row.risk_grade === "B"
+                        ? "bg-warning/10"
+                        : "bg-danger/10"
+                  }`}
+                >
+                  <p
+                    className={`text-2xl font-bold ${
+                      row.risk_grade === "A"
+                        ? "text-success"
+                        : row.risk_grade === "B"
+                          ? "text-warning"
+                          : "text-danger"
+                    }`}
+                  >
+                    {row.user_count}
+                  </p>
+                  <p className="text-xs text-text-muted mt-1">Grade {row.risk_grade}</p>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-text-secondary">No risk data yet.</p>
+          )}
+        </section>
+
+        {/* ML Integration placeholder — Member B's quant API */}
+        <section className="card-monzo p-5 space-y-3 border border-dashed border-coral/30">
+          <h2 className="text-xs font-semibold text-coral uppercase tracking-wider">
+            ML Credit Scoring (Quant API)
+          </h2>
+          <p className="text-sm text-text-secondary">
+            Backtest results, SHAP explanations, stress testing, and EDA will be available
+            here once the Quant API is connected.
+          </p>
+          <div className="grid grid-cols-2 gap-2 text-xs text-text-muted">
+            <div className="bg-warm-grey/50 rounded-lg p-3">POST /api/score</div>
+            <div className="bg-warm-grey/50 rounded-lg p-3">POST /api/explain</div>
+            <div className="bg-warm-grey/50 rounded-lg p-3">GET /api/backtest</div>
+            <div className="bg-warm-grey/50 rounded-lg p-3">POST /api/stress-test</div>
+            <div className="bg-warm-grey/50 rounded-lg p-3">GET /api/returns</div>
+            <div className="bg-warm-grey/50 rounded-lg p-3">GET /api/eda</div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+function StatCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="bg-warm-grey/30 rounded-xl p-3">
+      <p className="text-xs text-text-muted">{label}</p>
+      <p className="text-lg font-bold text-navy mt-0.5">{value}</p>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -21,6 +21,13 @@ export default async function SettingsPage() {
     .eq("id", user?.id ?? "")
     .single();
 
+  // Fetch lender preferences
+  const { data: lenderPrefs } = await supabase
+    .from("lender_preferences")
+    .select("min_apr, max_shift_days, risk_bands, auto_match_enabled")
+    .eq("user_id", user?.id ?? "")
+    .single();
+
   return (
     <SettingsClient
       email={user?.email ?? ""}
@@ -28,6 +35,7 @@ export default async function SettingsPage() {
       rolePreference={profile?.role_preference ?? "both"}
       connections={connections ?? []}
       onboardingCompleted={profile?.onboarding_completed ?? false}
+      lenderPrefs={lenderPrefs ?? undefined}
     />
   );
 }

--- a/apps/web/src/app/api/payments/topup/route.ts
+++ b/apps/web/src/app/api/payments/topup/route.ts
@@ -1,6 +1,72 @@
 import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
 
-export async function POST() {
-  // TODO: Integrate with Stripe for pot top-ups
-  return NextResponse.json({ error: "Not implemented" }, { status: 501 });
+export async function POST(request: Request) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Not authenticated" }, { status: 401 });
+  }
+
+  let body: { amount_pence?: number };
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const amountPence = body.amount_pence;
+  if (!amountPence || typeof amountPence !== "number" || amountPence <= 0) {
+    return NextResponse.json(
+      { error: "amount_pence must be a positive number" },
+      { status: 400 },
+    );
+  }
+
+  // Ensure lending pot exists
+  await supabase.from("lending_pots").upsert(
+    { user_id: user.id, available: 0, locked: 0, total_deployed: 0, realized_yield: 0 },
+    { onConflict: "user_id", ignoreDuplicates: true },
+  );
+
+  // Deposit via atomic RPC (row-level lock + ledger entry)
+  const amountGBP = amountPence / 100;
+  const { error } = await supabase.rpc("update_lending_pot", {
+    p_user_id: user.id,
+    p_entry_type: "DEPOSIT",
+    p_amount: amountGBP,
+    p_trade_id: null,
+    p_allocation_id: null,
+    p_description: `Top up £${amountGBP.toFixed(2)}`,
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: `Deposit failed: ${error.message}` },
+      { status: 500 },
+    );
+  }
+
+  // Fetch updated pot to return
+  const { data: pot } = await supabase
+    .from("lending_pots")
+    .select("available, locked, total_deployed, realized_yield")
+    .eq("user_id", user.id)
+    .single();
+
+  return NextResponse.json({
+    success: true,
+    pot: pot
+      ? {
+          available_pence: Math.round(Number(pot.available) * 100),
+          locked_pence: Math.round(Number(pot.locked) * 100),
+          total_deployed_pence: Math.round(Number(pot.total_deployed) * 100),
+          realized_yield_pence: Math.round(Number(pot.realized_yield) * 100),
+        }
+      : null,
+  });
 }

--- a/apps/web/src/components/lender/lender-hud.tsx
+++ b/apps/web/src/components/lender/lender-hud.tsx
@@ -14,6 +14,7 @@ interface LenderHudProps {
   pot: LendingPot | null;
   autoMatch: boolean;
   onAutoMatchToggle: (enabled: boolean) => void;
+  onTopUp?: () => void;
   position: HudPosition;
 }
 
@@ -43,6 +44,7 @@ export function LenderHud({
   pot,
   autoMatch,
   onAutoMatchToggle,
+  onTopUp,
   position,
 }: LenderHudProps) {
   if (position === "hidden") return null;
@@ -70,7 +72,10 @@ export function LenderHud({
           />
         </div>
         {showTopUp && (
-          <button className="w-full text-[10px] font-bold font-mono text-blue-200 border border-blue-500/30 rounded-md py-1.5 hover:bg-blue-500/10 transition-colors">
+          <button
+            onClick={onTopUp}
+            className="w-full text-[10px] font-bold font-mono text-blue-200 border border-blue-500/30 rounded-md py-1.5 hover:bg-blue-500/10 transition-colors"
+          >
             TOP UP
           </button>
         )}
@@ -99,7 +104,10 @@ export function LenderHud({
 
         <div className="flex items-center gap-2.5 shrink-0">
           {showTopUp && (
-            <button className="text-[10px] font-bold font-mono text-blue-200 border border-blue-500/30 rounded-md px-2.5 py-1 hover:bg-blue-500/10 transition-colors">
+            <button
+              onClick={onTopUp}
+              className="text-[10px] font-bold font-mono text-blue-200 border border-blue-500/30 rounded-md px-2.5 py-1 hover:bg-blue-500/10 transition-colors"
+            >
               TOP UP
             </button>
           )}

--- a/apps/web/src/components/settings/settings-client.tsx
+++ b/apps/web/src/components/settings/settings-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { useSupabase } from "@/lib/hooks/use-supabase";
@@ -9,6 +9,14 @@ import { useLenderSettings, BUBBLE_COLOR_PRESETS } from "@/lib/hooks/use-lender-
 import type { HudPosition, FilterMode, BubbleColorMode } from "@/lib/hooks/use-lender-settings";
 import { TopBar } from "@/components/layout/top-bar";
 import { Switch } from "@/components/ui/switch";
+import { updateLenderPreferences } from "@/lib/actions/lending";
+
+interface LenderPrefs {
+  min_apr: number;
+  max_shift_days: number;
+  risk_bands: string[];
+  auto_match_enabled: boolean;
+}
 
 interface SettingsClientProps {
   email: string;
@@ -21,6 +29,7 @@ interface SettingsClientProps {
     last_synced_at: string | null;
   }>;
   onboardingCompleted: boolean;
+  lenderPrefs?: LenderPrefs;
 }
 
 export function SettingsClient({
@@ -29,6 +38,7 @@ export function SettingsClient({
   rolePreference,
   connections,
   onboardingCompleted,
+  lenderPrefs,
 }: SettingsClientProps) {
   const supabase = useSupabase();
   const router = useRouter();
@@ -44,6 +54,17 @@ export function SettingsClient({
     setUnifiedColorHex,
   } = useLenderSettings();
   const [signingOut, setSigningOut] = useState(false);
+  const [isPrefSaving, startPrefTransition] = useTransition();
+
+  // Lender preference state
+  const [minApr, setMinApr] = useState(lenderPrefs?.min_apr ?? 5);
+  const [maxShiftDays, setMaxShiftDays] = useState(lenderPrefs?.max_shift_days ?? 14);
+  const [riskBands, setRiskBands] = useState<Set<string>>(
+    new Set(lenderPrefs?.risk_bands ?? ["A", "B", "C"]),
+  );
+  const [autoMatchEnabled, setAutoMatchEnabled] = useState(
+    lenderPrefs?.auto_match_enabled ?? false,
+  );
 
   // Notification preferences (UI only — no backend wiring)
   const [notifTradeUpdates, setNotifTradeUpdates] = useState(true);
@@ -60,6 +81,36 @@ export function SettingsClient({
 
   function handleConnectBank() {
     window.location.href = "/api/truelayer/auth";
+  }
+
+  function handleToggleRiskBand(band: string) {
+    setRiskBands((prev) => {
+      const next = new Set(prev);
+      if (next.has(band)) {
+        if (next.size > 1) next.delete(band);
+      } else {
+        next.add(band);
+      }
+      return next;
+    });
+  }
+
+  function handleSaveLenderPrefs() {
+    startPrefTransition(async () => {
+      try {
+        const formData = new FormData();
+        formData.set("min_apr", String(minApr));
+        formData.set("max_shift_days", String(maxShiftDays));
+        for (const band of riskBands) {
+          formData.append("risk_bands", band);
+        }
+        formData.set("auto_match_enabled", String(autoMatchEnabled));
+        await updateLenderPreferences(formData);
+        toast.success("Lending preferences saved");
+      } catch {
+        toast.error("Failed to save lending preferences");
+      }
+    });
   }
 
   return (
@@ -303,6 +354,102 @@ export function SettingsClient({
               </div>
             )}
           </div>
+        </section>
+
+        {/* Lending Preferences */}
+        <section className="card-monzo p-5 space-y-4">
+          <h2 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+            Lending Preferences
+          </h2>
+
+          {/* Auto-match */}
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="font-medium text-navy">Auto-match</p>
+              <p className="text-xs text-text-secondary">
+                Automatically fund trades matching your criteria
+              </p>
+            </div>
+            <Switch
+              checked={autoMatchEnabled}
+              onCheckedChange={setAutoMatchEnabled}
+            />
+          </div>
+
+          {/* Min APR */}
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <p className="font-medium text-navy">Minimum APR</p>
+              <span className="text-sm font-bold text-coral">{minApr}%</span>
+            </div>
+            <input
+              type="range"
+              min={0}
+              max={20}
+              step={0.5}
+              value={minApr}
+              onChange={(e) => setMinApr(Number(e.target.value))}
+              className="w-full h-1.5 bg-warm-grey rounded-full appearance-none cursor-pointer accent-coral"
+            />
+            <div className="flex justify-between text-[10px] text-text-muted mt-1">
+              <span>0%</span>
+              <span>20%</span>
+            </div>
+          </div>
+
+          {/* Max shift days */}
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <p className="font-medium text-navy">Max shift days</p>
+              <span className="text-sm font-bold text-coral">{maxShiftDays} days</span>
+            </div>
+            <input
+              type="range"
+              min={1}
+              max={90}
+              step={1}
+              value={maxShiftDays}
+              onChange={(e) => setMaxShiftDays(Number(e.target.value))}
+              className="w-full h-1.5 bg-warm-grey rounded-full appearance-none cursor-pointer accent-coral"
+            />
+            <div className="flex justify-between text-[10px] text-text-muted mt-1">
+              <span>1 day</span>
+              <span>90 days</span>
+            </div>
+          </div>
+
+          {/* Risk bands */}
+          <div>
+            <p className="font-medium text-navy mb-2">Accepted risk grades</p>
+            <div className="flex gap-2">
+              {(["A", "B", "C"] as const).map((band) => (
+                <button
+                  key={band}
+                  onClick={() => handleToggleRiskBand(band)}
+                  className={`flex-1 py-2.5 rounded-full text-sm font-bold transition-all ${
+                    riskBands.has(band)
+                      ? band === "A"
+                        ? "bg-success/15 text-success ring-1 ring-success/30"
+                        : band === "B"
+                          ? "bg-warning/15 text-warning ring-1 ring-warning/30"
+                          : "bg-danger/15 text-danger ring-1 ring-danger/30"
+                      : "bg-warm-grey text-text-muted"
+                  }`}
+                >
+                  {band}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Save button */}
+          <button
+            onClick={handleSaveLenderPrefs}
+            disabled={isPrefSaving}
+            className="w-full bg-coral text-white font-semibold py-2.5 rounded-full hover:bg-coral-dark transition-colors text-sm disabled:opacity-50 active:scale-95 transition-transform"
+          >
+            {isPrefSaving ? "Saving..." : "Save Lending Preferences"}
+          </button>
         </section>
 
         {/* Preferences */}

--- a/apps/web/src/lib/actions/trades.ts
+++ b/apps/web/src/lib/actions/trades.ts
@@ -11,8 +11,9 @@ export async function createTrade(formData: FormData) {
   } = await supabase.auth.getUser();
   if (!user) throw new Error("Not authenticated");
 
+  const rawObligationId = formData.get("obligation_id");
   const input = createTradeSchema.parse({
-    obligation_id: formData.get("obligation_id"),
+    obligation_id: rawObligationId && rawObligationId !== "" ? rawObligationId : undefined,
     original_due_date: formData.get("original_due_date"),
     new_due_date: formData.get("new_due_date") ?? formData.get("shifted_due_date"),
     amount_pence: Number(formData.get("amount_pence")),
@@ -24,7 +25,7 @@ export async function createTrade(formData: FormData) {
     .from("trades")
     .insert({
       borrower_id: user.id,
-      obligation_id: input.obligation_id,
+      obligation_id: input.obligation_id ?? null,
       original_due_date: input.original_due_date,
       new_due_date: input.new_due_date,
       amount: input.amount_pence / 100,

--- a/apps/web/src/lib/validators.ts
+++ b/apps/web/src/lib/validators.ts
@@ -17,7 +17,7 @@ export const signupSchema = z
   });
 
 export const createTradeSchema = z.object({
-  obligation_id: z.string().uuid(),
+  obligation_id: z.string().uuid().optional(),
   original_due_date: z.string().date(),
   new_due_date: z.string().date(),
   amount_pence: z.number().int().positive(),

--- a/supabase/migrations/014_analytics_views.sql
+++ b/supabase/migrations/014_analytics_views.sql
@@ -1,0 +1,41 @@
+-- 014: Analytics views for data dashboard and Member B's quant integrations
+
+-- Trade analytics: aggregated by risk_grade and status
+create or replace view public.trade_analytics as
+select
+  risk_grade,
+  status,
+  count(*) as trade_count,
+  round(avg(amount), 2) as avg_amount,
+  round(avg(fee), 2) as avg_fee,
+  round(avg(shift_days)::numeric, 1) as avg_shift_days,
+  round(sum(amount), 2) as total_volume,
+  round(sum(fee), 2) as total_fees,
+  count(*) filter (where status = 'DEFAULTED')::float
+    / nullif(count(*) filter (where status in ('REPAID', 'DEFAULTED')), 0) as default_rate
+from public.trades
+group by risk_grade, status;
+
+grant select on public.trade_analytics to authenticated;
+
+-- Risk distribution: user count per risk grade
+create or replace view public.risk_distribution as
+select
+  risk_grade,
+  count(*) as user_count
+from public.profiles
+where risk_grade is not null
+group by risk_grade;
+
+grant select on public.risk_distribution to authenticated;
+
+-- Pool overview: aggregate lending pot stats
+create or replace view public.pool_overview as
+select
+  count(*) as lender_count,
+  round(sum(available), 2) as total_available,
+  round(sum(locked), 2) as total_locked,
+  round(sum(available + locked), 2) as total_pool_size
+from public.lending_pots;
+
+grant select on public.pool_overview to authenticated;


### PR DESCRIPTION
## Summary

- **Fix obligation_id bug** in suggestion-feed: was passing proposal's own UUID instead of the obligation UUID, causing every "Accept" tap to crash
- **Implement lending pot top-up**: full API route (`/api/payments/topup`), HUD wiring, preset amount buttons in lending pot card, `withdrawFromPot` server action
- **Advanced matching (scored_v2)**: composite scoring (APR compatibility 40%, headroom 30%, diversification 30%), min_apr enforcement, max_total_exposure checks, 50% single-lender diversification cap
- **Settlement DEFAULT path**: LIVE trades past `new_due_date + 3 day` grace period → DEFAULTED, locked funds released back to lenders
- **Lender preferences UI**: full form in Settings with min APR slider, max shift days slider, risk band toggles (A/B/C)
- **Data & Analytics page** (`/data`): pool summary, trade analytics by grade, risk distribution — powered by 3 new Postgres views (migration 014)
- **PRD updated** with advanced matching algorithm, ML integration docs, top-up flow, settlement lifecycle, preferences, and analytics

## Files Changed (15)

| File | Change |
|------|--------|
| `suggestion-feed.tsx` | Fix obligation_id bug, add error state |
| `validators.ts` | Make obligation_id optional |
| `trades.ts` | Handle null/empty obligation_id |
| `topup/route.ts` | Full top-up implementation (was 501 stub) |
| `lending.ts` | Add topUpPot + withdrawFromPot actions |
| `lending-pot-card.tsx` | Interactive top-up UI with presets |
| `lender-hud.tsx` | Wire onTopUp prop to HUD buttons |
| `lender-page-client.tsx` | Add pot state + handleTopUp callback |
| `match-trade/index.ts` | Advanced scored matching v2 |
| `settle-trade/index.ts` | Add Phase 3: LIVE → DEFAULTED |
| `settings/page.tsx` | Fetch + pass lender preferences |
| `settings-client.tsx` | Lender preferences form section |
| `data/page.tsx` | **NEW** — Analytics dashboard |
| `014_analytics_views.sql` | **NEW** — Postgres aggregate views |
| `PRD.md` | Advanced features documentation |

## Integrates with Member B's work
- match-trade optionally calls Member B's Quant API for ML-powered PD scoring (graceful degradation)
- /data page has placeholder section ready for Member B's FastAPI endpoints (backtest, EDA, SHAP, stress-test)
- Uses Member B's bubble color customization and lender settings hooks

## Test plan
- [ ] Accept a seed proposal → trade created, no crash
- [ ] Lender → tap "Top Up" → pot balance increases
- [ ] Create trade → auto-match considers APR, exposure limits, ranks lenders by score
- [ ] Cron settlement → LIVE trades past grace period → DEFAULTED
- [ ] Settings → set min APR, risk bands → saved to DB
- [ ] Navigate to /data → page renders with pool + trade analytics
- [ ] `pnpm build` succeeds (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)