### PR TITLE
Add Claude code review GitHub Action

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          direct_prompt: |
+          prompt: |
             Review this PR for:
             1. Code quality and TypeScript best practices
             2. Potential bugs or regressions
@@ -36,4 +36,3 @@ jobs:
             Context: This is a Next.js 15 + Supabase fintech app (P2P micro-lending).
             All monetary values should be in pence (integers), converted to pounds only at display.
             Trade lifecycle: DRAFT -> PENDING_MATCH -> MATCHED -> LIVE -> REPAID/DEFAULTED.
-          model: claude-sonnet-4-5-20241022


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-review.yml` using `anthropics/claude-code-action@v1`
- Auto-reviews PRs on open/sync, also responds to `@claude` mentions in PR comments
- Reviews for code quality, security, Supabase patterns, and fintech-specific logic
- `ANTHROPIC_API_KEY` secret already configured

## Test plan
- [ ] This PR itself should trigger the review workflow
- [ ] Verify Claude posts a review comment on this PR
- [ ] Test `@claude` mention in a comment

Generated with [Claude Code](https://claude.com/claude-code)