### PR TITLE
feat(quant): real-time transaction scoring pipeline

### DIFF
--- a/quant_analysis/api/main.py
+++ b/quant_analysis/api/main.py
@@ -6,21 +6,26 @@ Run locally:
 
 Endpoints
 ---------
-POST /api/score            Credit score, PD, grade
-POST /api/explain          SHAP explanation waterfall data
-GET  /api/lenders          Simulated lender pool
-GET  /api/backtest         Historical default rates by grade
-POST /api/stress-test      Score delta under income shock
-GET  /api/returns          Portfolio yield & Sharpe ratio
-GET  /api/eda              EDA summary stats + correlation matrix
-GET  /api/forecast-accuracy MAPE time-series mock
+POST /api/score              Credit score, PD, grade
+POST /api/explain            SHAP explanation waterfall data
+GET  /api/lenders            Simulated lender pool
+GET  /api/backtest           Historical default rates by grade
+POST /api/stress-test        Score delta under income shock
+GET  /api/returns            Portfolio yield & Sharpe ratio
+GET  /api/eda                EDA summary stats + correlation matrix
+GET  /api/forecast-accuracy  MAPE time-series mock
+POST /api/transaction        Ingest one transaction, return updated score
+POST /api/transaction/batch  Bootstrap from historical transactions, return score
 """
 
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+import statistics
+from typing import Optional
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 # ── Lazy imports populated at startup ─────────────────────────────────────────
 import sys
@@ -101,6 +106,174 @@ class BorrowerFeatures(BaseModel):
         ]
 
 
+# ── In-memory per-user transaction state ─────────────────────────────────────
+# Aligned with compute-borrower-features Edge Function feature semantics.
+
+USER_STATE: dict[str, dict] = {}
+
+# Keywords from Edge Function + user requirements (union)
+FAILED_KEYWORDS = frozenset([
+    "failed", "rejected", "bounced", "returned",
+    "unpaid", "nsf", "insufficient", "overdraft",
+])
+
+_MAX_BALANCE_SNAPSHOTS = 500
+
+
+def _default_user_state() -> dict:
+    return {
+        "total_inflow": 0.0,       # sum of credits (GBP)
+        "total_outflow": 0.0,      # abs sum of debits (GBP)
+        "txn_count": 0,
+        "earliest_date": None,     # datetime | None — account-age proxy
+        "monthly_inflows": {},     # "YYYY-MM" -> float — for income regularity CV
+        "balance_snapshots": [],   # list[float] — running net history, capped at 500
+        "running_net": 0.0,        # current credits - debits
+        "failed_flags": 0,         # count of transactions matching FAILED_KEYWORDS
+    }
+
+
+def _get_or_create_state(user_id: str) -> dict:
+    if user_id not in USER_STATE:
+        USER_STATE[user_id] = _default_user_state()
+    return USER_STATE[user_id]
+
+
+class Transaction(BaseModel):
+    user_id: str
+    amount: float = Field(..., description="Positive = credit, negative = debit (GBP)")
+    transaction_type: str = Field(..., description="CREDIT or DEBIT")
+    description: Optional[str] = Field(None, description="Merchant/payment narrative")
+    booked_at: datetime = Field(..., description="ISO 8601 booking timestamp")
+
+    @field_validator("booked_at", mode="before")
+    @classmethod
+    def parse_booked_at(cls, v: object) -> datetime:
+        """Handle 'Z' suffix that Supabase emits (Python 3.10 fromisoformat rejects it)."""
+        if isinstance(v, str):
+            return datetime.fromisoformat(v.replace("Z", "+00:00"))
+        return v
+
+    @field_validator("transaction_type", mode="before")
+    @classmethod
+    def normalise_type(cls, v: object) -> str:
+        return v.upper().strip() if isinstance(v, str) else v
+
+
+class TransactionBatch(BaseModel):
+    transactions: list[Transaction] = Field(
+        ..., min_length=1, max_length=5000,
+        description="List of transactions — send oldest-first for correct date tracking.",
+    )
+
+
+def _update_state(state: dict, txn: Transaction) -> None:
+    """Mutate user state in-place with one transaction."""
+    is_credit = txn.amount > 0 and txn.transaction_type == "CREDIT"
+    is_debit  = txn.amount < 0 or  txn.transaction_type == "DEBIT"
+
+    if is_credit:
+        state["total_inflow"] += txn.amount
+        month_key = txn.booked_at.strftime("%Y-%m")
+        state["monthly_inflows"][month_key] = (
+            state["monthly_inflows"].get(month_key, 0.0) + txn.amount
+        )
+    elif is_debit:
+        state["total_outflow"] += abs(txn.amount)
+
+    state["txn_count"] += 1
+    state["running_net"] += txn.amount
+    state["balance_snapshots"].append(state["running_net"])
+    if len(state["balance_snapshots"]) > _MAX_BALANCE_SNAPSHOTS:
+        state["balance_snapshots"] = state["balance_snapshots"][-_MAX_BALANCE_SNAPSHOTS:]
+
+    txn_dt = txn.booked_at
+    if not txn_dt.tzinfo:
+        txn_dt = txn_dt.replace(tzinfo=timezone.utc)
+    if state["earliest_date"] is None or txn_dt < state["earliest_date"]:
+        state["earliest_date"] = txn_dt
+
+    desc = (txn.description or "").lower()
+    if any(kw in desc for kw in FAILED_KEYWORDS):
+        state["failed_flags"] += 1
+
+
+def _compute_features(state: dict) -> BorrowerFeatures:
+    """Recalculate all 6 ML features from current in-memory state."""
+    now = datetime.now(tz=timezone.utc)
+    earliest = state["earliest_date"]
+    days_elapsed   = max(1, (now - earliest).days) if earliest else 1
+    months_elapsed = max(1, days_elapsed // 30)
+
+    # annual_inflow: time-aware annualization (matches Edge Function intent)
+    annual_inflow = (state["total_inflow"] / days_elapsed) * 365
+
+    # avg_monthly_balance: running net / months
+    avg_monthly_balance = state["running_net"] / months_elapsed
+
+    # days_since_account_open
+    days_since_open = float(days_elapsed)
+
+    # primary_bank_health_score: 1 - CV(monthly inflows) — income regularity
+    mv = list(state["monthly_inflows"].values())
+    if len(mv) >= 2 and statistics.mean(mv) > 0:
+        cv = statistics.stdev(mv) / statistics.mean(mv)
+        primary = float(max(0.0, min(1.0, 1.0 - cv)))
+    else:
+        primary = 0.5  # neutral: not enough monthly history yet
+
+    # secondary_bank_health_score: 1 - (balance_volatility × 0.3) — balance stability
+    snaps = state["balance_snapshots"]
+    if len(snaps) >= 2:
+        mean_s = statistics.mean(snaps)
+        vol = statistics.stdev(snaps) / abs(mean_s) if abs(mean_s) > 1e-9 else 1.0
+        secondary = float(max(0.1, min(1.0, 1.0 - vol * 0.3)))
+    else:
+        secondary = 0.5
+
+    # failed_payment_cluster_risk: exact 3-bucket from Edge Function
+    fc = state["failed_flags"]
+    if fc == 0:
+        failed_risk = 1.0
+    elif fc <= 2:
+        failed_risk = 2.0
+    else:
+        failed_risk = 3.0
+
+    return BorrowerFeatures(
+        annual_inflow=round(annual_inflow, 2),
+        avg_monthly_balance=round(avg_monthly_balance, 2),
+        days_since_account_open=days_since_open,
+        primary_bank_health_score=round(primary, 4),
+        secondary_bank_health_score=round(secondary, 4),
+        failed_payment_cluster_risk=failed_risk,
+    )
+
+
+def _score_response(user_id: str, state: dict, batch_size: int | None = None) -> dict:
+    """Compute score from current state and return standard response shape."""
+    features     = _compute_features(state)
+    pd_value     = get_pd(features.to_list())
+    credit_score = pd_to_score(pd_value)
+    grade        = get_risk_grade(credit_score)
+
+    out: dict = {
+        "user_id": user_id,
+        "credit_score": round(credit_score, 2),
+        "probability_of_default": round(pd_value, 6),
+        "risk_grade": grade,
+        "updated_features": features.model_dump(),
+        "metadata": {
+            "txn_count": state["txn_count"],
+            "failed_flags": state["failed_flags"],
+            "monthly_income_buckets": len(state["monthly_inflows"]),
+        },
+    }
+    if batch_size is not None:
+        out["metadata"]["batch_size"] = batch_size
+    return out
+
+
 # ── Endpoints ─────────────────────────────────────────────────────────────────
 
 @app.get("/health")
@@ -161,6 +334,38 @@ def stress_test(body: StressTestRequest):
     """Return credit-score delta after applying an income-shock multiplier."""
     result = stress_test_borrower(body.features.to_list(), body.income_multiplier)
     return result
+
+
+@app.post("/api/transaction")
+def ingest_transaction(txn: Transaction):
+    """
+    Ingest one Open Banking transaction for a user.
+    Updates in-memory financial state, recomputes all 6 ML features,
+    and returns a fresh credit score instantly.
+    """
+    state = _get_or_create_state(txn.user_id)
+    _update_state(state, txn)
+    return _score_response(txn.user_id, state)
+
+
+@app.post("/api/transaction/batch")
+def ingest_transaction_batch(body: TransactionBatch):
+    """
+    Bootstrap a user's state from a list of historical transactions.
+    Send oldest-first for correct account-age tracking.
+    All transactions must share the same user_id.
+    """
+    user_ids = {t.user_id for t in body.transactions}
+    if len(user_ids) > 1:
+        raise HTTPException(
+            status_code=400,
+            detail="All transactions in a batch must share the same user_id.",
+        )
+    user_id = user_ids.pop()
+    state = _get_or_create_state(user_id)
+    for txn in body.transactions:
+        _update_state(state, txn)
+    return _score_response(user_id, state, batch_size=len(body.transactions))
 
 
 @app.get("/api/returns")


### PR DESCRIPTION
## Summary
- Adds `POST /api/transaction` — ingest one Open Banking transaction, update in-memory state, return a fresh credit score instantly
- Adds `POST /api/transaction/batch` — bootstrap a user's state from up to 5,000 historical transactions
- Feature formulas aligned with `compute-borrower-features` Edge Function for system-wide consistency

## How it works
Each transaction updates a per-user in-memory state dict. All 6 ML features are recalculated and passed through the existing XGBoost → scorecard pipeline:

| Feature | Formula |
|---|---|
| `annual_inflow` | `(total_inflow / days_elapsed) × 365` |
| `avg_monthly_balance` | `running_net / months_elapsed` |
| `primary_bank_health_score` | `1 - CV(monthly inflows)` — income regularity |
| `secondary_bank_health_score` | `1 - (balance_volatility × 0.3)` |
| `failed_payment_cluster_risk` | 3-bucket: 0 failed→1.0, 1-2→2.0, 3+→3.0 |

## Test plan
- [ ] `POST /api/transaction` with a salary credit returns score in 300–850 range
- [ ] Second call with a "returned" debit increments `failed_payment_cluster_risk` to 2.0 and lowers score
- [ ] `POST /api/transaction/batch` with mixed transactions returns consistent result
- [ ] `POST /api/transaction/batch` with two different `user_id`s returns HTTP 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)