### PR TITLE
fix: TrueLayer token exchange diagnostic logging (#41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Flowzo is a Monzo-native "Bills + Pots" fintech webapp with a pooled P2P micro-l
 ### Git Workflow
 - **Never push directly to `main`** — always use feature branches + PRs
 - Multiple Claude Code instances run in parallel — **always use worktrees** (`/worktree` or `EnterWorktree`) to avoid conflicts
+- **Worktree convention**: Use `EnterWorktree` at the start of every task. This creates an isolated copy under `.claude/worktrees/<name>` on a new branch. On session exit, you'll be prompted to keep or remove it. Worktrees prevent merge conflicts between parallel Claude Code sessions and keep the main working tree clean.
 - Commit messages: conventional commits style
 - Claude code review runs automatically on PRs via `anthropics/claude-code-action@v1`
 

--- a/apps/web/src/app/(app)/onboarding/page.tsx
+++ b/apps/web/src/app/(app)/onboarding/page.tsx
@@ -107,7 +107,7 @@ export default async function OnboardingPage({
             <p className="text-xs text-text-secondary">
               {params.error === "no_code" && "Bank connection was cancelled. You can try again."}
               {params.error === "invalid_state" && "Security check failed. Please try again."}
-              {params.error === "token_exchange_failed" && "Failed to connect to your bank. This can happen with sandbox credentials — please try again."}
+              {params.error === "token_exchange_failed" && "Failed to connect to your bank. Please wait a moment and try again."}
               {params.error === "storage_failed" && "Failed to save your connection. Please try again."}
             </p>
             <div className="flex items-center justify-center gap-3">

--- a/apps/web/src/app/api/truelayer/callback/route.ts
+++ b/apps/web/src/app/api/truelayer/callback/route.ts
@@ -10,6 +10,8 @@ export async function GET(request: Request) {
   const code = searchParams.get("code");
   const state = searchParams.get("state");
 
+  console.log(`[TrueLayer Callback] origin=${origin}, redirect_uri=${origin}/api/truelayer/callback`);
+
   if (!code) {
     return NextResponse.redirect(`${origin}/onboarding?error=no_code`);
   }
@@ -126,7 +128,12 @@ export async function GET(request: Request) {
 
     return NextResponse.redirect(`${origin}/borrower`);
   } catch (error) {
-    console.error("TrueLayer token exchange failed:", error);
+    console.error(
+      "[TrueLayer Callback] Token exchange failed:",
+      error instanceof Error ? error.message : error,
+      `\n  origin: ${origin}`,
+      `\n  code present: ${!!code}`,
+    );
     return NextResponse.redirect(`${origin}/onboarding?error=token_exchange_failed`);
   }
 }

--- a/apps/web/src/lib/truelayer/auth.ts
+++ b/apps/web/src/lib/truelayer/auth.ts
@@ -34,8 +34,18 @@ export async function exchangeCode(
   });
 
   if (!res.ok) {
-    const error = await res.text();
-    throw new Error(`TrueLayer token exchange failed: ${error}`);
+    const body = await res.text();
+    const redirectUri = getRedirectUri(origin);
+    console.error(
+      `[TrueLayer] Token exchange failed (${res.status})`,
+      `\n  redirect_uri: ${redirectUri}`,
+      `\n  client_id: ${TRUELAYER_CONFIG.clientId.slice(0, 8)}...`,
+      `\n  env: ${TRUELAYER_CONFIG.env}`,
+      `\n  response: ${body}`,
+    );
+    throw new Error(
+      `TrueLayer token exchange failed (${res.status}): ${body} [redirect_uri=${redirectUri}]`,
+    );
   }
 
   return res.json();

--- a/apps/web/src/lib/truelayer/config.ts
+++ b/apps/web/src/lib/truelayer/config.ts
@@ -21,3 +21,13 @@ export const TRUELAYER_CONFIG = {
 export function getRedirectUri(origin: string): string {
   return `${origin}/api/truelayer/callback`;
 }
+
+// Startup validation — warn if TrueLayer is misconfigured
+if (typeof process !== "undefined" && process.env) {
+  if (!TRUELAYER_CONFIG.clientId) {
+    console.warn("[TrueLayer] TRUELAYER_CLIENT_ID is not set — bank connections will fail");
+  }
+  if (!TRUELAYER_CONFIG.clientSecret) {
+    console.warn("[TrueLayer] TRUELAYER_CLIENT_SECRET is not set — token exchange will fail");
+  }
+}


### PR DESCRIPTION
## Summary
- Adds diagnostic logging to TrueLayer OAuth token exchange so redirect URI mismatches are immediately visible in Vercel logs
- Logs origin + redirect_uri at callback entry, and includes redirect_uri/client_id/env in error messages
- Fixes user-facing error message to be environment-neutral (removes "sandbox credentials" mention)
- Adds startup validation warnings when `TRUELAYER_CLIENT_ID` or `TRUELAYER_CLIENT_SECRET` are missing
- Documents worktree convention in CLAUDE.md

Closes #41

## Manual steps still required
1. **TrueLayer Console** → Register `https://flowzo-web.vercel.app/api/truelayer/callback` as redirect URI
2. **Vercel Dashboard** → Verify `TRUELAYER_CLIENT_ID`, `TRUELAYER_CLIENT_SECRET` env vars are set
3. Stale `sync_failed` bank_connections already cleaned up via Supabase SQL

## Test plan
- [ ] Merge PR and deploy to Vercel
- [ ] Register redirect URI in TrueLayer Console
- [ ] Test bank connect flow on production with `john` / `doe`
- [ ] Verify redirect to `/borrower` without `token_exchange_failed`
- [ ] Check Vercel logs show `[TrueLayer Callback] origin=...` on callback hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)