### PR TITLE
feat: add inline display name editing on settings page

### DIFF
--- a/apps/web/src/lib/actions/profile.ts
+++ b/apps/web/src/lib/actions/profile.ts
@@ -1,0 +1,27 @@
+"use server";
+
+import { z } from "zod";
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+const displayNameSchema = z.string().trim().min(1, "Name cannot be empty").max(50, "Name must be 50 characters or less");
+
+export async function updateDisplayName(formData: FormData) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const displayName = displayNameSchema.parse(formData.get("displayName"));
+
+  const { error } = await supabase
+    .from("profiles")
+    .update({ display_name: displayName })
+    .eq("id", user.id);
+
+  if (error) throw new Error(`Failed to update display name: ${error.message}`);
+
+  revalidatePath("/settings");
+}


### PR DESCRIPTION
## Summary
- Add `updateDisplayName` server action (`lib/actions/profile.ts`) with Zod validation (trimmed, 1–50 chars), auth check, and Supabase profile update
- Replace read-only display name block in settings with inline editable field: pencil icon to enter edit mode, text input + Save/Cancel buttons
- Keyboard shortcuts (Enter to save, Escape to cancel) and toast feedback via sonner

## Test plan
- [ ] Go to `/settings`, verify display name shows with pencil edit icon
- [ ] Click edit → input appears pre-filled with current name
- [ ] Change name, click Save → toast confirms, name updates
- [ ] Try empty name → client-side validation prevents save
- [ ] Press Escape or Cancel → reverts to original name
- [ ] Reload page → new name persists from DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)