### PR TITLE
fix: refresh lending pot balance after top-up

### DIFF
--- a/apps/web/src/components/lender/lender-page-client.tsx
+++ b/apps/web/src/components/lender/lender-page-client.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import { TopBar } from "@/components/layout/top-bar";
 import { LendingPotCard } from "./lending-pot-card";
 import { YieldDashboard } from "./yield-dashboard";
@@ -33,6 +34,7 @@ export function LenderPageClient({
   currentApyBps,
   sparklineData,
 }: LenderPageClientProps) {
+  const router = useRouter();
 
   return (
     <div>
@@ -44,7 +46,7 @@ export function LenderPageClient({
         />
 
         {/* Lending Pot Card */}
-        <LendingPotCard pot={initialPot} currentApyBps={currentApyBps} />
+        <LendingPotCard pot={initialPot} currentApyBps={currentApyBps} onPotUpdated={() => router.refresh()} />
 
         {/* Yield Dashboard */}
         <YieldDashboard


### PR DESCRIPTION
## Summary
- Wire the existing `onPotUpdated` callback on `LendingPotCard` to `router.refresh()` in the parent `LenderPageClient`
- After a top-up, the server component re-fetches the updated balance immediately — no manual page reload needed

## Test plan
- [ ] Go to `/lender`, top up any amount
- [ ] Balance updates immediately after toast appears
- [ ] No full page reload occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)