### PR TITLE
fix: dashboard data pipeline — quant crash, depth chart, pagination, performance

### DIFF
--- a/apps/web/src/app/(app)/data/page.tsx
+++ b/apps/web/src/app/(app)/data/page.tsx
@@ -83,28 +83,24 @@ export default async function DataPage() {
     risk_grade: row.risk_grade as string,
     matched_count: Number(row.matched_count ?? 0),
     avg_hours_to_match: Number(row.avg_hours_to_match ?? 0),
-    median_hours_to_match: Number(row.avg_hours_to_match ?? 0),
-    fastest_match_hours: 0,
-    slowest_match_hours: 0,
+    median_hours_to_match: Number(row.median_hours_to_match ?? row.avg_hours_to_match ?? 0),
+    fastest_match_hours: Number(row.fastest_match_hours ?? 0),
+    slowest_match_hours: Number(row.slowest_match_hours ?? 0),
   }));
 
   // ── Map trade_performance → SettlementRow ───────────────────────────────
-  const settlement = (performance ?? []).map((row) => {
-    const repaidCount = Number(row.repaid_count ?? 0);
-    const defaultedCount = Number(row.defaulted_count ?? 0);
-    const settledCount = repaidCount + defaultedCount;
-    return {
-      risk_grade: row.risk_grade as string,
-      repaid_count: repaidCount,
-      defaulted_count: defaultedCount,
-      live_count: 0,
-      default_rate_pct:
-        settledCount > 0 ? Number(((defaultedCount / settledCount) * 100).toFixed(1)) : 0,
-      avg_days_to_repay: 0,
-      total_fees_earned: Number(row.avg_fee_repaid ?? 0) * repaidCount,
-      total_defaulted_volume: null,
-    };
-  });
+  const settlement = (performance ?? []).map((row) => ({
+    risk_grade: row.risk_grade as string,
+    repaid_count: Number(row.repaid_count ?? 0),
+    defaulted_count: Number(row.defaulted_count ?? 0),
+    live_count: Number(row.live_count ?? 0),
+    default_rate_pct: Number(row.default_rate ?? 0) * 100,
+    avg_days_to_repay: Number(row.avg_days_to_repay ?? 0),
+    total_fees_earned: Number(row.total_fees_earned ?? 0),
+    total_defaulted_volume: row.total_defaulted_volume != null
+      ? Number(row.total_defaulted_volume)
+      : null,
+  }));
 
   // ── Compute yield trends from repaid trades ─────────────────────────────
   const monthlyMap = new Map<

--- a/apps/web/src/components/data/data-page-client.tsx
+++ b/apps/web/src/components/data/data-page-client.tsx
@@ -390,6 +390,14 @@ function OrderBookTab({
   orderBook: OrderBookRow[];
   pendingTrades: PendingTrade[];
 }) {
+  const [page, setPage] = useState(0);
+  const PAGE_SIZE = 10;
+  const totalPages = Math.ceil(pendingTrades.length / PAGE_SIZE);
+  const paginatedTrades = pendingTrades.slice(
+    page * PAGE_SIZE,
+    (page + 1) * PAGE_SIZE,
+  );
+
   function hoursAgo(dateStr: string): string {
     const h = Math.round(
       (Date.now() - new Date(dateStr).getTime()) / 3600000,
@@ -458,10 +466,10 @@ function OrderBookTab({
         />
       </section>
 
-      {/* Full Order List */}
+      {/* Pending Trades (paginated) */}
       <section className="card-monzo p-5 space-y-3">
         <h2 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
-          All Pending Trades ({pendingTrades.length})
+          Pending Trades ({pendingTrades.length})
         </h2>
         <DataTable
           columns={[
@@ -517,9 +525,30 @@ function OrderBookTab({
               ),
             },
           ]}
-          data={pendingTrades}
+          data={paginatedTrades}
           emptyMessage="No pending trades in the order book."
         />
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between pt-2">
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={page === 0}
+              className="px-3 py-1 rounded-full text-xs font-semibold bg-warm-grey/50 text-text-secondary hover:bg-warm-grey disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              Previous
+            </button>
+            <span className="text-xs text-text-muted">
+              Page {page + 1} of {totalPages}
+            </span>
+            <button
+              onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+              disabled={page >= totalPages - 1}
+              className="px-3 py-1 rounded-full text-xs font-semibold bg-warm-grey/50 text-text-secondary hover:bg-warm-grey disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              Next
+            </button>
+          </div>
+        )}
       </section>
     </div>
   );

--- a/supabase/migrations/018_extended_dashboard_views.sql
+++ b/supabase/migrations/018_extended_dashboard_views.sql
@@ -1,0 +1,86 @@
+-- 018: Extended matching & settlement analytics
+-- NOTE: DROP + CREATE because CREATE OR REPLACE cannot reorder/rename columns
+
+-- Extend matching_efficiency with median, min, max hours
+drop view if exists public.matching_efficiency cascade;
+create view public.matching_efficiency as
+select
+  risk_grade,
+  count(*) filter (where status in ('MATCHED', 'LIVE', 'REPAID')) as matched_count,
+  count(*) filter (where status = 'PENDING_MATCH') as pending_count,
+  round(
+    count(*) filter (where status in ('MATCHED', 'LIVE', 'REPAID'))::numeric
+    / nullif(count(*), 0),
+    4
+  ) as fill_rate,
+  round(
+    avg(
+      extract(epoch from (matched_at - created_at)) / 3600
+    ) filter (where matched_at is not null),
+    1
+  ) as avg_hours_to_match,
+  round(
+    percentile_cont(0.5) within group (
+      order by extract(epoch from (matched_at - created_at)) / 3600
+    ) filter (where matched_at is not null)::numeric,
+    1
+  ) as median_hours_to_match,
+  round(
+    min(
+      extract(epoch from (matched_at - created_at)) / 3600
+    ) filter (where matched_at is not null)::numeric,
+    1
+  ) as fastest_match_hours,
+  round(
+    max(
+      extract(epoch from (matched_at - created_at)) / 3600
+    ) filter (where matched_at is not null)::numeric,
+    1
+  ) as slowest_match_hours
+from trades
+group by risk_grade;
+
+grant select on public.matching_efficiency to authenticated;
+alter view public.matching_efficiency set (security_invoker = true);
+
+-- Extend trade_performance with live_count, avg_days_to_repay, defaulted volume, total fees
+drop view if exists public.trade_performance cascade;
+create view public.trade_performance as
+select
+  risk_grade,
+  count(*) filter (where status = 'REPAID') as repaid_count,
+  count(*) filter (where status = 'DEFAULTED') as defaulted_count,
+  count(*) filter (where status = 'LIVE') as live_count,
+  count(*) filter (where status in ('REPAID', 'DEFAULTED')) as settled_count,
+  round(
+    count(*) filter (where status = 'DEFAULTED')::numeric
+    / nullif(count(*) filter (where status in ('REPAID', 'DEFAULTED')), 0),
+    4
+  ) as default_rate,
+  round(avg(amount) filter (where status in ('REPAID', 'DEFAULTED')), 2) as avg_amount,
+  round(avg(fee) filter (where status = 'REPAID'), 2) as avg_fee_repaid,
+  round(
+    avg((fee / nullif(amount, 0)) * (365.0 / nullif(shift_days, 0)) * 100)
+    filter (where status = 'REPAID' and amount > 0 and shift_days > 0),
+    2
+  ) as avg_apr_pct,
+  round(
+    avg(
+      extract(epoch from (repaid_at - live_at)) / 86400
+    ) filter (where status = 'REPAID' and repaid_at is not null and live_at is not null),
+    1
+  ) as avg_days_to_repay,
+  round(
+    sum(amount) filter (where status = 'DEFAULTED'),
+    2
+  ) as total_defaulted_volume,
+  round(
+    sum(fee) filter (where status = 'REPAID'),
+    2
+  ) as total_fees_earned
+from trades
+where status in ('REPAID', 'DEFAULTED', 'LIVE')
+group by risk_grade;
+
+grant select on public.trade_performance to authenticated;
+alter view public.trade_performance set (security_invoker = true);


### PR DESCRIPTION
## Summary
- **Fix ML/Quant crash**: `ForecastSection` was accessing `data.time_series.map()` but API returns `{days, actual, forecasted, mape_pct}` — aligned interface and component
- **Fix depth chart X-axis**: Dynamic tick spacing (max 6 labels) + 45° rotation to prevent overlap. Added Q1/median/Q3 statistical overlays and APR stats row
- **Paginate pending trades**: Replaced "show all" 50-row table with 10/page pagination (Previous/Next)
- **Fix performance hardcoded zeros**: Extended `matching_efficiency` view (median/fastest/slowest hours) and `trade_performance` view (live_count, avg_days_to_repay, total_defaulted_volume, total_fees_earned). Migration 018 already applied to remote
- **Idempotent seed script**: Reuses existing users, cleans demo data before re-seeding

## Test plan
- [ ] Navigate to `/data` — Overview tab shows live trade counts, pool stats, yield
- [ ] Order Book tab: depth chart X-axis labels readable, median line visible, pagination works on pending trades
- [ ] Performance tab: match speed shows real median/range, settlement shows avg days and fees
- [ ] Yield tab: monthly yield table populated
- [ ] ML/Quant tab: Forecast subtab loads without crash
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)