### PR TITLE
fix: dashboard audit — APR guards, quant retry, platform totals

### DIFF
--- a/apps/web/src/app/(app)/data/page.tsx
+++ b/apps/web/src/app/(app)/data/page.tsx
@@ -59,12 +59,22 @@ export default async function DataPage() {
   };
 
   // ── Map order_book_depth → OrderBookRow ─────────────────────────────────
+  // Compute oldest pending trade per grade from raw pending trades
+  const oldestByGrade = new Map<string, string>();
+  for (const t of pendingTradesRaw ?? []) {
+    const grade = t.risk_grade as string;
+    const created = t.created_at as string;
+    const existing = oldestByGrade.get(grade);
+    if (!existing || created < existing) oldestByGrade.set(grade, created);
+  }
+
   const orderBook = (orderBookRaw ?? []).map((row) => {
     const avgAmount = Number(row.avg_amount ?? 0);
     const avgFee = Number(row.avg_fee ?? 0);
     const avgTermDays = Number(row.avg_term_days ?? 1);
+    const grade = row.risk_grade as string;
     return {
-      risk_grade: row.risk_grade as string,
+      risk_grade: grade,
       pending_count: Number(row.trade_count ?? 0),
       total_amount: Number(row.total_amount ?? 0),
       avg_amount: avgAmount,
@@ -74,7 +84,7 @@ export default async function DataPage() {
         avgAmount > 0 && avgTermDays > 0
           ? Number(((avgFee / avgAmount) * (365 / avgTermDays) * 100).toFixed(1))
           : 0,
-      oldest_pending: new Date().toISOString(),
+      oldest_pending: oldestByGrade.get(grade) ?? new Date().toISOString(),
     };
   });
 

--- a/apps/web/src/components/data/data-page-client.tsx
+++ b/apps/web/src/components/data/data-page-client.tsx
@@ -498,9 +498,11 @@ function OrderBookTab({
               align: "right",
               render: (r: PendingTrade) => {
                 const apr =
-                  (Number(r.fee) / Number(r.amount)) *
-                  (365 / r.shift_days) *
-                  100;
+                  r.amount > 0 && r.shift_days > 0
+                    ? (Number(r.fee) / Number(r.amount)) *
+                      (365 / r.shift_days) *
+                      100
+                    : 0;
                 return (
                   <span className="font-bold text-success">
                     {apr.toFixed(1)}%

--- a/apps/web/src/components/data/depth-chart.tsx
+++ b/apps/web/src/components/data/depth-chart.tsx
@@ -42,8 +42,9 @@ export function DepthChart({ pendingTrades }: DepthChartProps) {
     const bucketMap = new Map<string, DepthBucket>();
 
     for (const trade of pendingTrades) {
-      if (!trade.amount || !trade.shift_days || trade.shift_days === 0) continue;
+      if (!trade.amount || !trade.shift_days || trade.shift_days === 0 || trade.fee == null) continue;
       const apr = (trade.fee / trade.amount) * (365 / trade.shift_days) * 100;
+      if (!isFinite(apr)) continue;
       const bucket = Math.floor(apr / BUCKET_WIDTH) * BUCKET_WIDTH;
       const key = `${bucket}-${trade.risk_grade}`;
 
@@ -98,8 +99,9 @@ export function DepthChart({ pendingTrades }: DepthChartProps) {
     // Compute APR statistics from individual trades
     const allAprs: number[] = [];
     for (const trade of pendingTrades) {
-      if (!trade.amount || !trade.shift_days || trade.shift_days === 0) continue;
-      allAprs.push((trade.fee / trade.amount) * (365 / trade.shift_days) * 100);
+      if (!trade.amount || !trade.shift_days || trade.shift_days === 0 || trade.fee == null) continue;
+      const tradeApr = (trade.fee / trade.amount) * (365 / trade.shift_days) * 100;
+      if (isFinite(tradeApr)) allAprs.push(tradeApr);
     }
     allAprs.sort((a, b) => a - b);
 


### PR DESCRIPTION
## Summary
- **APR division-by-zero**: Guard against `shift_days === 0` and `amount === 0` in depth chart and pending trades table
- **oldest_pending fix**: Compute from actual pending trade `created_at` timestamps per grade instead of hardcoded `now()`
- **Quant API proxy**: Add 15s timeout, proper error surfacing, timeout detection
- **Quant dashboard**: Add retry button on error, response validation, force-refresh support
- **platform_totals view**: Add `matched_trades`, `cancelled_trades`, `total_fees_collected`, `total_trades` columns
- **Lender leaderboard**: Rename dual-role users from "Borrower XXX" to "Lender XXX"

## Test plan
- [ ] Load `/data` page — verify pool health shows matched/cancelled counts and total fees
- [ ] Order Book tab — pending trades with 0 shift_days don't show NaN APR
- [ ] Market depth chart — no NaN in APR buckets or statistics
- [ ] Lender leaderboard — no "Borrower" names appear
- [ ] ML/Quant tab — error state shows retry button; clicking retry refetches data
- [ ] `pnpm build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)