### PR TITLE
fix: analytics views RLS + dark mode chart styling

### DIFF
--- a/apps/web/src/components/data/data-table.tsx
+++ b/apps/web/src/components/data/data-table.tsx
@@ -16,7 +16,7 @@ export function DataTable<T>({
   data,
   emptyMessage = "No data available.",
 }: DataTableProps<T>) {
-  if (data.length === 0) {
+  if (!Array.isArray(data) || data.length === 0) {
     return <p className="text-sm text-text-secondary">{emptyMessage}</p>;
   }
 

--- a/apps/web/src/components/data/depth-chart.tsx
+++ b/apps/web/src/components/data/depth-chart.tsx
@@ -224,7 +224,7 @@ export function DepthChart({ pendingTrades }: DepthChartProps) {
                 y1={yScale(tick)}
                 x2={W - PAD.right}
                 y2={yScale(tick)}
-                stroke="#E5E7EB"
+                style={{ stroke: "var(--warm-grey)" }}
                 strokeWidth="0.5"
                 strokeDasharray="2,2"
               />
@@ -273,7 +273,7 @@ export function DepthChart({ pendingTrades }: DepthChartProps) {
               y={PAD.top}
               width={Math.max(0, xScale(aprStats.q3) - xScale(aprStats.q1))}
               height={plotH}
-              fill="rgba(27, 27, 58, 0.06)"
+              style={{ fill: "var(--navy)", opacity: 0.08 }}
               rx="2"
             />
           )}
@@ -286,7 +286,7 @@ export function DepthChart({ pendingTrades }: DepthChartProps) {
                 y1={PAD.top}
                 x2={xScale(aprStats.median)}
                 y2={PAD.top + plotH}
-                stroke="#1B1B3A"
+                style={{ stroke: "var(--navy)" }}
                 strokeWidth="1"
                 strokeDasharray="4,3"
               />
@@ -350,7 +350,7 @@ export function DepthChart({ pendingTrades }: DepthChartProps) {
         {/* Tooltip */}
         {hoveredBucket && (
           <div
-            className="absolute pointer-events-none bg-navy text-white text-[10px] rounded-lg px-2.5 py-1.5 shadow-lg z-10"
+            className="absolute pointer-events-none bg-navy-bg text-white text-[10px] rounded-lg px-2.5 py-1.5 shadow-lg z-10"
             style={{
               left: `${hoveredBucket.x}px`,
               top: `${hoveredBucket.y - 10}px`,

--- a/apps/web/src/components/data/quant-dashboard.tsx
+++ b/apps/web/src/components/data/quant-dashboard.tsx
@@ -412,7 +412,7 @@ function ForecastSection({ data }: { data: ForecastAccuracy }) {
             {/* Actual line */}
             <polyline
               fill="none"
-              stroke="#1B1B3A"
+              style={{ stroke: "var(--navy)" }}
               strokeWidth="1.5"
               points={data.actual
                 .map(

--- a/supabase/migrations/018_extended_dashboard_views.sql
+++ b/supabase/migrations/018_extended_dashboard_views.sql
@@ -41,7 +41,7 @@ from trades
 group by risk_grade;
 
 grant select on public.matching_efficiency to authenticated;
-alter view public.matching_efficiency set (security_invoker = true);
+alter view public.matching_efficiency set (security_invoker = false);
 
 -- Extend trade_performance with live_count, avg_days_to_repay, defaulted volume, total fees
 drop view if exists public.trade_performance cascade;
@@ -83,7 +83,7 @@ where status in ('REPAID', 'DEFAULTED', 'LIVE')
 group by risk_grade;
 
 grant select on public.trade_performance to authenticated;
-alter view public.trade_performance set (security_invoker = true);
+alter view public.trade_performance set (security_invoker = false);
 
 -- Extend platform_totals with matched/cancelled counts and total fees
 drop view if exists public.platform_totals cascade;
@@ -100,7 +100,7 @@ select
 from trades;
 
 grant select on public.platform_totals to authenticated;
-alter view public.platform_totals set (security_invoker = true);
+alter view public.platform_totals set (security_invoker = false);
 
 -- Fix lender names: rename dual-role users showing as "Borrower" in leaderboard
 update profiles

--- a/supabase/migrations/019_fix_analytics_view_permissions.sql
+++ b/supabase/migrations/019_fix_analytics_view_permissions.sql
@@ -1,0 +1,20 @@
+-- 019: Fix analytics view permissions
+-- Remove security_invoker=true from all analytics views.
+-- These are aggregate platform-level views that should show ALL data
+-- to any authenticated user, not be filtered by RLS on underlying tables.
+
+alter view public.lender_concentration set (security_invoker = false);
+alter view public.lender_leaderboard set (security_invoker = false);
+alter view public.match_speed_analytics set (security_invoker = false);
+alter view public.matching_efficiency set (security_invoker = false);
+alter view public.order_book_depth set (security_invoker = false);
+alter view public.order_book_summary set (security_invoker = false);
+alter view public.pool_health set (security_invoker = false);
+alter view public.pool_overview set (security_invoker = false);
+alter view public.pool_summary set (security_invoker = false);
+alter view public.risk_distribution set (security_invoker = false);
+alter view public.settlement_performance set (security_invoker = false);
+alter view public.trade_analytics set (security_invoker = false);
+alter view public.trade_performance set (security_invoker = false);
+alter view public.yield_curve set (security_invoker = false);
+alter view public.yield_trends set (security_invoker = false);


### PR DESCRIPTION
## Summary
- **Root cause of empty dashboard found**: All 15 analytics views had `security_invoker=true`, causing RLS on underlying tables to filter data to only the logged-in user's rows. Dashboard showed 1 lender, 0 repaid, etc. despite 1,065 trades, 255 lenders, £257K capital in the DB.
- **Fix**: Removed `security_invoker` from all analytics views — they are aggregate platform-level views that should show ALL data to any authenticated user.
- **Dark mode tooltip**: Depth chart tooltip used `bg-navy` which inverts to light in dark mode, making white text unreadable. Changed to `bg-navy-bg` (stays dark in both modes).
- **SVG dark mode**: Grid lines, median line, Q1-Q3 band, and forecast chart now use CSS variables instead of hardcoded colors.
- **DataTable crash guard**: Added `Array.isArray()` check to prevent "a.map is not a function" if non-array data reaches the table.

## Test plan
- [ ] Load `/data` page — should now show ~255 lenders, ~159 live trades, ~579 repaid, £209 yield
- [ ] Match Speed table should show real data (277 Grade A matched, etc.)
- [ ] Settlement table should show repaid/defaulted counts per grade
- [ ] Depth chart tooltip readable in dark mode (dark bg, white text)
- [ ] SVG grid lines visible in dark mode
- [ ] No "a.map is not a function" errors
- [ ] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)