### PR TITLE
feat: mock data fallback for profile achievements

### DIFF
--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -61,6 +61,22 @@ export default async function SettingsPage() {
       .filter(Boolean),
   );
 
+  // Fall back to mock data when no real achievements exist
+  const hasRealAchievements = borrowerSavedPence > 0 || lenderAmountPence > 0;
+  const achievements = hasRealAchievements
+    ? {
+        borrowerSavedPence,
+        borrowerTradeCount,
+        lenderAmountPence,
+        lenderPeopleHelped: uniqueBorrowers.size,
+      }
+    : {
+        borrowerSavedPence: 124350,   // £1,243.50
+        borrowerTradeCount: 8,
+        lenderAmountPence: 351200,    // £3,512.00
+        lenderPeopleHelped: 14,
+      };
+
   return (
     <SettingsClient
       email={user?.email ?? ""}
@@ -69,12 +85,7 @@ export default async function SettingsPage() {
       connections={connections ?? []}
       onboardingCompleted={profile?.onboarding_completed ?? false}
       lenderPrefs={lenderPrefs ?? undefined}
-      achievements={{
-        borrowerSavedPence,
-        borrowerTradeCount,
-        lenderAmountPence,
-        lenderPeopleHelped: uniqueBorrowers.size,
-      }}
+      achievements={achievements}
     />
   );
 }


### PR DESCRIPTION
## Summary
- When no real repaid trades/allocations exist, the Profile achievements section now shows demo stats instead of being empty
- Mock data: £1,243.50 saved across 8 bill shifts, 14 people helped with £3,512.00 in overdraft prevented

## Test plan
- [ ] Log in as a user with no repaid trades — verify mock achievement data displays
- [ ] Log in as a user with repaid trades — verify real data takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)