### PR TITLE
feat: action buttons on balance card (Monzo-style)

### DIFF
--- a/apps/web/src/app/(app)/borrower/page.tsx
+++ b/apps/web/src/app/(app)/borrower/page.tsx
@@ -261,10 +261,47 @@ export default async function BorrowerHomePage() {
                 </div>
               </div>
               <div className="flex items-end justify-between mt-1">
-                <p className="text-xs font-medium opacity-70">
-                  {displayName !== "there" ? displayName : "Current Account"}
-                </p>
+                <div className="flex items-center gap-1.5">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-3.5 h-3.5 opacity-70">
+                    <path d="M3 21h18" /><path d="M3 10h18" /><path d="M12 3l9 7H3l9-7z" />
+                    <path d="M5 10v11" /><path d="M19 10v11" /><path d="M9 10v11" /><path d="M14 10v11" />
+                  </svg>
+                  <p className="text-xs font-medium opacity-70">
+                    {displayName !== "there" ? displayName : "Current Account"}
+                  </p>
+                </div>
                 <p className="text-xs font-medium opacity-70">Balance</p>
+              </div>
+              {/* Action buttons */}
+              <div className="flex items-center gap-2.5 mt-4">
+                <Link
+                  href="#suggestions"
+                  className="flex items-center gap-1.5 bg-white/20 hover:bg-white/30 transition-colors px-4 py-2 rounded-full text-sm font-semibold"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-11.25a.75.75 0 00-1.5 0v2.5h-2.5a.75.75 0 000 1.5h2.5v2.5a.75.75 0 001.5 0v-2.5h2.5a.75.75 0 000-1.5h-2.5v-2.5z" clipRule="evenodd" />
+                  </svg>
+                  Shift Bill
+                </Link>
+                <Link
+                  href="/onboarding"
+                  className="flex items-center gap-1.5 bg-white/20 hover:bg-white/30 transition-colors px-4 py-2 rounded-full text-sm font-semibold"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
+                    <path fillRule="evenodd" d="M15.312 11.424a5.5 5.5 0 01-9.201 2.466l-.312-.311h2.433a.75.75 0 000-1.5H4.598a.75.75 0 00-.75.75v3.634a.75.75 0 001.5 0v-2.033l.312.311a7 7 0 0011.712-3.138.75.75 0 00-1.449-.39zm-1.872-5.603a.75.75 0 00-.162-.81l-.312-.311a7 7 0 00-11.712 3.138.75.75 0 001.449.39 5.5 5.5 0 019.201-2.466l.312.311H9.783a.75.75 0 000 1.5h3.634a.75.75 0 00.75-.75V3.407a.75.75 0 00-1.5 0v2.033l-.312-.311a.746.746 0 00.085.692z" clipRule="evenodd" />
+                  </svg>
+                  Sync
+                </Link>
+                <div className="ml-auto">
+                  <Link
+                    href="/settings"
+                    className="flex items-center justify-center w-9 h-9 rounded-full bg-[rgba(0,0,0,0.2)] hover:bg-[rgba(0,0,0,0.3)] transition-colors"
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5">
+                      <path d="M3 10a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zm5.5 0a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zm7-1.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3z" />
+                    </svg>
+                  </Link>
+                </div>
               </div>
             </div>
           );


### PR DESCRIPTION
## Summary
- Added bank icon + account name row (matching Monzo's sort code / account number row)
- Added three action buttons at the bottom of the balance card:
  - **Shift Bill** (+ icon) — scrolls to suggestions
  - **Sync** (refresh icon) — links to bank onboarding/sync
  - **...** (dark circle) — links to Profile/settings
- Buttons use `bg-white/20` pill style matching Monzo's translucent button treatment

## Test plan
- [ ] Verify balance card shows bank icon, account name, and three action buttons
- [ ] Verify "Shift Bill" scrolls to suggestions section
- [ ] Verify "Sync" navigates to /onboarding
- [ ] Verify "..." navigates to /settings (Profile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)