### PR TITLE
feat: Card & Scheduled Payments demo pages

### DIFF
--- a/apps/web/src/app/(app)/borrower/card/page.tsx
+++ b/apps/web/src/app/(app)/borrower/card/page.tsx
@@ -1,0 +1,141 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { TopBar } from "@/components/layout/top-bar";
+
+export default async function CardPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("display_name")
+    .eq("id", user.id)
+    .single();
+
+  const cardholderName = profile?.display_name ?? "Flowzo User";
+
+  return (
+    <div className="max-w-lg sm:max-w-2xl mx-auto">
+      <TopBar title="Card" />
+
+      <div className="px-4 py-6 space-y-6">
+        {/* Card visual */}
+        <div className="rounded-2xl bg-coral p-6 text-white aspect-[1.6/1] flex flex-col justify-between shadow-lg">
+          <div className="flex items-start justify-between">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.5} className="w-10 h-10 opacity-80">
+              <rect x="1" y="4" width="10" height="8" rx="1" />
+              <line x1="3" y1="7" x2="9" y2="7" />
+              <line x1="3" y1="9" x2="7" y2="9" />
+            </svg>
+            <p className="text-2xl font-extrabold tracking-tight">flowzo</p>
+          </div>
+          <div className="flex items-end justify-between">
+            <p className="text-sm font-medium opacity-80 tracking-wider">
+              {cardholderName}
+            </p>
+            <div className="flex -space-x-2">
+              <div className="w-8 h-8 rounded-full bg-red-500 opacity-80" />
+              <div className="w-8 h-8 rounded-full bg-yellow-400 opacity-80" />
+            </div>
+          </div>
+        </div>
+
+        {/* Quick actions */}
+        <div className="grid grid-cols-2 gap-3">
+          <button className="card-monzo p-4 flex flex-col items-center gap-2 text-center opacity-60 cursor-not-allowed">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-6 h-6 text-coral">
+              <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+              <path d="M7 11V7a5 5 0 0110 0v4" />
+            </svg>
+            <span className="text-sm font-semibold text-navy">Reveal PIN</span>
+            <span className="text-[10px] text-text-muted">Coming soon</span>
+          </button>
+          <button className="card-monzo p-4 flex flex-col items-center gap-2 text-center opacity-60 cursor-not-allowed">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" className="w-6 h-6 text-blue-500">
+              <path d="M12 2a5 5 0 015 5v1H7V7a5 5 0 015-5z" />
+              <line x1="8" y1="14" x2="8" y2="18" />
+              <line x1="12" y1="12" x2="12" y2="18" />
+              <line x1="16" y1="16" x2="16" y2="18" />
+            </svg>
+            <span className="text-sm font-semibold text-navy">Freeze Card</span>
+            <span className="text-[10px] text-text-muted">Coming soon</span>
+          </button>
+        </div>
+
+        {/* Card details */}
+        <section className="card-monzo p-5 space-y-0">
+          <div className="flex items-center justify-between pb-3">
+            <h2 className="text-sm font-bold text-navy">Card details</h2>
+            <span className="text-xs text-text-muted">Demo</span>
+          </div>
+          <div className="divide-y divide-warm-grey">
+            <div className="flex items-center justify-between py-3">
+              <span className="text-sm text-text-secondary">Name on card</span>
+              <span className="text-sm font-medium text-navy">{cardholderName}</span>
+            </div>
+            <div className="flex items-center justify-between py-3">
+              <span className="text-sm text-text-secondary">Card number</span>
+              <span className="text-sm font-medium text-navy font-mono tracking-wider">
+                &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; 4921
+              </span>
+            </div>
+            <div className="flex items-center justify-between py-3">
+              <span className="text-sm text-text-secondary">Expiry</span>
+              <span className="text-sm font-medium text-navy">03/28</span>
+            </div>
+            <div className="flex items-center justify-between py-3">
+              <span className="text-sm text-text-secondary">CVC</span>
+              <span className="text-sm text-text-muted">&bull;&bull;&bull;</span>
+            </div>
+          </div>
+        </section>
+
+        {/* Spending limits */}
+        <section className="card-monzo p-5 space-y-3">
+          <h2 className="text-sm font-bold text-navy">Spending limits</h2>
+          <div className="space-y-3">
+            <div>
+              <div className="flex items-center justify-between text-xs mb-1">
+                <span className="text-text-secondary">Contactless</span>
+                <span className="text-navy font-medium">£100 / day</span>
+              </div>
+              <div className="h-1.5 rounded-full bg-warm-grey overflow-hidden">
+                <div className="h-full rounded-full bg-coral w-1/4" />
+              </div>
+            </div>
+            <div>
+              <div className="flex items-center justify-between text-xs mb-1">
+                <span className="text-text-secondary">Online</span>
+                <span className="text-navy font-medium">£500 / day</span>
+              </div>
+              <div className="h-1.5 rounded-full bg-warm-grey overflow-hidden">
+                <div className="h-full rounded-full bg-success w-1/6" />
+              </div>
+            </div>
+            <div>
+              <div className="flex items-center justify-between text-xs mb-1">
+                <span className="text-text-secondary">ATM withdrawal</span>
+                <span className="text-navy font-medium">£300 / day</span>
+              </div>
+              <div className="h-1.5 rounded-full bg-warm-grey overflow-hidden">
+                <div className="h-full rounded-full bg-warning w-0" />
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <Link
+          href="/borrower"
+          className="block text-center text-sm text-coral font-semibold py-2"
+        >
+          Back to Bills
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/borrower/page.tsx
+++ b/apps/web/src/app/(app)/borrower/page.tsx
@@ -287,7 +287,7 @@ export default async function BorrowerHomePage() {
               <div className="flex items-center gap-2 mt-3">
                 <Link
                   href="#suggestions"
-                  className="flex items-center gap-1.5 bg-white/20 hover:bg-white/30 transition-colors px-4 py-2 rounded-full text-sm font-semibold"
+                  className="flex items-center gap-1.5 bg-white/20 hover:bg-white/30 active:scale-95 transition-all px-4 py-2 rounded-full text-sm font-semibold"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
                     <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm.75-11.25a.75.75 0 00-1.5 0v2.5h-2.5a.75.75 0 000 1.5h2.5v2.5a.75.75 0 001.5 0v-2.5h2.5a.75.75 0 000-1.5h-2.5v-2.5z" clipRule="evenodd" />
@@ -295,18 +295,18 @@ export default async function BorrowerHomePage() {
                   Shift Bill
                 </Link>
                 <Link
-                  href="/onboarding"
-                  className="flex items-center gap-1.5 bg-white/20 hover:bg-white/30 transition-colors px-4 py-2 rounded-full text-sm font-semibold"
+                  href="/borrower/card"
+                  className="flex items-center gap-1.5 bg-white/20 hover:bg-white/30 active:scale-95 transition-all px-4 py-2 rounded-full text-sm font-semibold"
                 >
                   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4">
-                    <path fillRule="evenodd" d="M15.312 11.424a5.5 5.5 0 01-9.201 2.466l-.312-.311h2.433a.75.75 0 000-1.5H4.598a.75.75 0 00-.75.75v3.634a.75.75 0 001.5 0v-2.033l.312.311a7 7 0 0011.712-3.138.75.75 0 00-1.449-.39zm-1.872-5.603a.75.75 0 00-.162-.81l-.312-.311a7 7 0 00-11.712 3.138.75.75 0 001.449.39 5.5 5.5 0 019.201-2.466l.312.311H9.783a.75.75 0 000 1.5h3.634a.75.75 0 00.75-.75V3.407a.75.75 0 00-1.5 0v2.033l-.312-.311a.746.746 0 00.085.692z" clipRule="evenodd" />
+                    <path d="M2.5 4A1.5 1.5 0 001 5.5V6h18v-.5A1.5 1.5 0 0017.5 4h-15zM19 8.5H1v6A1.5 1.5 0 002.5 16h15a1.5 1.5 0 001.5-1.5v-6zM3 13.25A.75.75 0 013.75 12.5h1.5a.75.75 0 010 1.5h-1.5A.75.75 0 013 13.25zm4.75-.75a.75.75 0 000 1.5h3.5a.75.75 0 000-1.5h-3.5z" />
                   </svg>
-                  Sync
+                  Card
                 </Link>
                 <div className="ml-auto">
                   <Link
-                    href="/settings"
-                    className="flex items-center justify-center w-9 h-9 rounded-full bg-[rgba(0,0,0,0.2)] hover:bg-[rgba(0,0,0,0.3)] transition-colors"
+                    href="/borrower/scheduled"
+                    className="flex items-center justify-center w-9 h-9 rounded-full bg-[rgba(0,0,0,0.2)] hover:bg-[rgba(0,0,0,0.3)] active:scale-95 transition-all"
                   >
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-5 h-5">
                       <path d="M3 10a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zm5.5 0a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0zm7-1.5a1.5 1.5 0 100 3 1.5 1.5 0 000-3z" />

--- a/apps/web/src/app/(app)/borrower/scheduled/page.tsx
+++ b/apps/web/src/app/(app)/borrower/scheduled/page.tsx
@@ -1,0 +1,190 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { TopBar } from "@/components/layout/top-bar";
+import { formatCurrency } from "@flowzo/shared";
+
+function formatShortDate(dateStr: string): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    day: "numeric",
+    month: "short",
+  }).format(new Date(dateStr));
+}
+
+function demoDate(daysFromNow: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + daysFromNow);
+  return d.toISOString().split("T")[0];
+}
+
+interface ScheduledItem {
+  id: string;
+  name: string;
+  amount_pence: number;
+  date: string;
+  type: "direct_debit" | "standing_order" | "shift_repayment";
+  frequency?: string;
+}
+
+export default async function ScheduledPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) redirect("/login");
+
+  // Fetch real obligations
+  const today = new Date();
+  const sixtyDaysLater = new Date(today);
+  sixtyDaysLater.setDate(today.getDate() + 60);
+
+  const { data: obligations } = await supabase
+    .from("obligations")
+    .select("id, name, amount, frequency, next_expected, merchant_name")
+    .eq("user_id", user.id)
+    .eq("active", true)
+    .gte("next_expected", today.toISOString().split("T")[0])
+    .lte("next_expected", sixtyDaysLater.toISOString().split("T")[0])
+    .order("next_expected", { ascending: true });
+
+  // Fetch active trade repayments
+  const { data: activeTrades } = await supabase
+    .from("trades")
+    .select("id, amount, fee, new_due_date, obligations(name)")
+    .eq("borrower_id", user.id)
+    .in("status", ["MATCHED", "LIVE"])
+    .order("new_due_date", { ascending: true });
+
+  // Build scheduled items from real data or demo
+  let items: ScheduledItem[] = [];
+
+  if (obligations && obligations.length > 0) {
+    for (const o of obligations) {
+      items.push({
+        id: o.id,
+        name: o.name ?? o.merchant_name ?? "Bill",
+        amount_pence: Math.round(Number(o.amount) * 100),
+        date: o.next_expected,
+        type: "direct_debit",
+        frequency: o.frequency,
+      });
+    }
+  }
+
+  if (activeTrades && activeTrades.length > 0) {
+    for (const t of activeTrades) {
+      const obligation = Array.isArray(t.obligations) ? t.obligations[0] : t.obligations;
+      items.push({
+        id: `repay-${t.id}`,
+        name: obligation?.name ?? "Bill shift repayment",
+        amount_pence: Math.round((Number(t.amount) + Number(t.fee)) * 100),
+        date: t.new_due_date,
+        type: "shift_repayment",
+      });
+    }
+  }
+
+  // Demo fallback
+  if (items.length === 0) {
+    items = [
+      { id: "d1", name: "Netflix", amount_pence: 1599, date: demoDate(3), type: "direct_debit", frequency: "MONTHLY" },
+      { id: "d2", name: "Spotify", amount_pence: 1099, date: demoDate(3), type: "direct_debit", frequency: "MONTHLY" },
+      { id: "d3", name: "EE Mobile", amount_pence: 3500, date: demoDate(7), type: "direct_debit", frequency: "MONTHLY" },
+      { id: "d4", name: "British Gas", amount_pence: 12800, date: demoDate(10), type: "direct_debit", frequency: "MONTHLY" },
+      { id: "d5", name: "Council Tax", amount_pence: 18000, date: demoDate(10), type: "standing_order", frequency: "MONTHLY" },
+      { id: "d6", name: "Energy Bill (shifted)", amount_pence: 8971, date: demoDate(14), type: "shift_repayment" },
+      { id: "d7", name: "Thames Water", amount_pence: 4200, date: demoDate(17), type: "direct_debit", frequency: "MONTHLY" },
+      { id: "d8", name: "PureGym", amount_pence: 2499, date: demoDate(22), type: "direct_debit", frequency: "MONTHLY" },
+      { id: "d9", name: "Aviva Insurance", amount_pence: 5500, date: demoDate(28), type: "direct_debit", frequency: "MONTHLY" },
+      { id: "d10", name: "Council Tax (shifted)", amount_pence: 14342, date: demoDate(30), type: "shift_repayment" },
+    ];
+  }
+
+  items.sort((a, b) => a.date.localeCompare(b.date));
+
+  const totalPence = items.reduce((sum, i) => sum + i.amount_pence, 0);
+  const directDebits = items.filter((i) => i.type === "direct_debit");
+  const standingOrders = items.filter((i) => i.type === "standing_order");
+  const shiftRepayments = items.filter((i) => i.type === "shift_repayment");
+
+  return (
+    <div className="max-w-lg sm:max-w-2xl mx-auto">
+      <TopBar title="Scheduled Payments" />
+
+      <div className="px-4 py-6 space-y-6">
+        {/* Summary */}
+        <div className="card-monzo p-5">
+          <p className="text-xs text-text-muted uppercase tracking-wider">Total upcoming</p>
+          <p className="text-2xl font-extrabold text-navy mt-1">
+            {formatCurrency(totalPence)}
+          </p>
+          <p className="text-xs text-text-secondary mt-1">
+            {items.length} payments in the next 60 days
+          </p>
+        </div>
+
+        {/* Counts */}
+        <div className="grid grid-cols-3 gap-3">
+          <div className="card-monzo p-3 text-center">
+            <p className="text-lg font-bold text-navy">{directDebits.length}</p>
+            <p className="text-[10px] text-text-muted">Direct Debits</p>
+          </div>
+          <div className="card-monzo p-3 text-center">
+            <p className="text-lg font-bold text-navy">{standingOrders.length}</p>
+            <p className="text-[10px] text-text-muted">Standing Orders</p>
+          </div>
+          <div className="card-monzo p-3 text-center">
+            <p className="text-lg font-bold text-coral">{shiftRepayments.length}</p>
+            <p className="text-[10px] text-text-muted">Shift Repayments</p>
+          </div>
+        </div>
+
+        {/* Timeline */}
+        <section className="card-monzo p-5">
+          <h2 className="text-sm font-bold text-navy mb-3">Upcoming</h2>
+          <div className="space-y-0 divide-y divide-warm-grey">
+            {items.map((item) => (
+              <div key={item.id} className="flex items-center gap-3 py-3">
+                <div className="w-10 text-center shrink-0">
+                  <p className="text-xs font-bold text-navy">{formatShortDate(item.date)}</p>
+                </div>
+                <div className={`w-8 h-8 rounded-full flex items-center justify-center shrink-0 ${
+                  item.type === "shift_repayment" ? "bg-coral/10" : item.type === "standing_order" ? "bg-blue-500/10" : "bg-warning/10"
+                }`}>
+                  {item.type === "shift_repayment" ? (
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="w-4 h-4 text-coral">
+                      <path fillRule="evenodd" d="M10 1a4.5 4.5 0 00-4.5 4.5V9H5a2 2 0 00-2 2v6a2 2 0 002 2h10a2 2 0 002-2v-6a2 2 0 00-2-2h-.5V5.5A4.5 4.5 0 0010 1zm3 8V5.5a3 3 0 10-6 0V9h6z" clipRule="evenodd" />
+                    </svg>
+                  ) : (
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className={`w-4 h-4 ${item.type === "standing_order" ? "text-blue-500" : "text-warning"}`}>
+                      <path fillRule="evenodd" d="M10 3a.75.75 0 01.75.75V15.388l3.96-4.158a.75.75 0 111.08 1.04l-5.25 5.5a.75.75 0 01-1.08 0l-5.25-5.5a.75.75 0 111.08-1.04l3.96 4.158V3.75A.75.75 0 0110 3z" clipRule="evenodd" />
+                    </svg>
+                  )}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-navy truncate">{item.name}</p>
+                  <p className="text-[10px] text-text-muted">
+                    {item.type === "shift_repayment" ? "Shift repayment (locked)" :
+                     item.type === "standing_order" ? "Standing order" :
+                     `Direct debit${item.frequency ? ` · ${item.frequency.charAt(0) + item.frequency.slice(1).toLowerCase()}` : ""}`}
+                  </p>
+                </div>
+                <p className={`text-sm font-bold shrink-0 ${item.type === "shift_repayment" ? "text-coral" : "text-navy"}`}>
+                  -{formatCurrency(item.amount_pence)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        <Link
+          href="/borrower"
+          className="block text-center text-sm text-coral font-semibold py-2"
+        >
+          Back to Bills
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds `/borrower/card` page with Monzo-style card visual, card details, spending limits, and placeholder actions (Reveal PIN, Freeze Card)
- Adds `/borrower/scheduled` page showing upcoming direct debits, standing orders, and shift repayments from real obligations + active trades (with demo fallback)
- Updates balance card action buttons to link to real pages: "Shift Bill" → #suggestions anchor, "Card" → /borrower/card, "..." → /borrower/scheduled

## Test plan
- [ ] Navigate to /borrower and verify the 3 action buttons work
- [ ] Verify /borrower/card renders card visual, details, and spending limits
- [ ] Verify /borrower/scheduled shows timeline of upcoming payments
- [ ] Verify demo fallback data appears when no real obligations exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)