### PR TITLE
fix: inverted yield curve

### DIFF
--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -742,12 +742,10 @@ async function createTrades(users: SeedUser[], lenders: SeedUser[], obligationsM
     const shiftDays = randomInt(1, 14);
     const amount = randomFloat(10, 500);
     const feeRate = 0.049 * (borrower.riskGrade === "A" ? 1 : borrower.riskGrade === "B" ? 1.5 : 2);
+    // Fee = rate * amount * days/365 — no flat % cap so APR stays consistent across term lengths
     const fee = Math.max(
       0.01,
-      Math.min(
-        Math.round(feeRate * amount * (shiftDays / 365) * 100) / 100,
-        Math.min(amount * 0.05, 10),
-      ),
+      Math.round(feeRate * amount * (shiftDays / 365) * 100) / 100,
     );
 
     let originalDueDate: Date;
@@ -1067,12 +1065,10 @@ async function createProposals(users: SeedUser[], obligationsMap: Map<string, Se
         : borrower.riskGrade === "B"
           ? 1.5
           : 2);
+    // Fee = rate * amount * days/365 — no flat % cap so APR stays consistent across term lengths
     const fee = Math.max(
       0.01,
-      Math.min(
-        Math.round(feeRate * amount * (shiftDays / 365) * 100) / 100,
-        Math.min(amount * 0.05, 10),
-      ),
+      Math.round(feeRate * amount * (shiftDays / 365) * 100) / 100,
     );
 
     // Pick and fill a template

--- a/supabase/migrations/021_fix_yield_curve_inversion.sql
+++ b/supabase/migrations/021_fix_yield_curve_inversion.sql
@@ -1,0 +1,29 @@
+-- Fix inverted yield curve: only use REPAID trades (realized yields)
+-- Previously included LIVE and MATCHED trades which mix unrealized projections
+-- with actual settled returns, distorting APR calculations.
+create or replace view public.yield_curve as
+select
+  risk_grade,
+  case
+    when shift_days <= 7 then '0-7d'
+    when shift_days <= 14 then '8-14d'
+    when shift_days <= 30 then '15-30d'
+    else '30d+'
+  end as term_bucket,
+  count(*) as trade_count,
+  round(
+    avg((fee / nullif(amount, 0)) * (365.0 / nullif(shift_days, 0)) * 100),
+    2
+  ) as avg_apr_pct,
+  round(avg(fee), 2) as avg_fee
+from trades
+where status = 'REPAID'
+  and amount > 0
+  and shift_days > 0
+group by risk_grade, term_bucket;
+
+-- Keep permissions
+grant select on public.yield_curve to authenticated;
+
+-- Restore security_invoker = false (matches migration 019)
+alter view public.yield_curve set (security_invoker = false);


### PR DESCRIPTION
## Summary

- **Yield curve view filtered to REPAID only** — previously included LIVE and MATCHED trades, mixing unrealized projections with realized yields and distorting APR averages
- **Seed script fee cap removed** — the `Math.min(amount * 0.05, 10)` cap caused longer-term trades to show lower annualized APR than shorter ones (a flat 5% cap annualizes to ~260% for 7d but ~130% for 14d)

## Root cause

The `yield_curve` view in migration 016 aggregated trades with status `('REPAID', 'LIVE', 'MATCHED')`. LIVE/MATCHED trades have fees that haven't settled yet, creating a mix of actual and projected yields that skewed the averages per term bucket.

## Test plan

- [ ] Apply migration 021: `supabase db push`
- [ ] Re-seed: `source apps/web/.env.local && npx tsx scripts/seed.ts`
- [ ] Check `/data` yield tab — APR should increase monotonically with term length (7d < 14d < 30d)
- [ ] Check `/lender` duration selector — yields should be non-inverted

🤖 Generated with [Claude Code](https://claude.com/claude-code)