### PR TITLE
feat: order book supply/demand + data quality fixes

### DIFF
--- a/apps/web/src/app/(app)/lender/page.tsx
+++ b/apps/web/src/app/(app)/lender/page.tsx
@@ -123,17 +123,17 @@ export default async function LenderHomePage() {
     activeTrades: activeTrades.length,
   };
 
-  // Fetch yield curve for duration selector (dynamic APR per term bucket)
-  const { data: yieldCurve } = await supabase
-    .from("yield_curve")
+  // Fetch aggregated yield curve (volume-weighted across all grades per bucket)
+  const { data: yieldCurveAgg } = await supabase
+    .from("yield_curve_agg")
     .select("term_bucket, avg_apr_pct, trade_count");
 
   const potPence = Math.round(Number(pot?.available ?? 0) * 100);
   const fallbackApr = currentApyBps / 100; // bps → percent
 
-  // Map yield_curve buckets to duration options
-  const shortBucket = yieldCurve?.find((r) => r.term_bucket === "0-7d");
-  const midBucket = yieldCurve?.find((r) => r.term_bucket === "8-14d");
+  // Map yield_curve_agg buckets to duration options (one row per bucket, no grade ambiguity)
+  const shortBucket = yieldCurveAgg?.find((r) => r.term_bucket === "0-7d");
+  const midBucket = yieldCurveAgg?.find((r) => r.term_bucket === "8-14d");
 
   const shortApr = Number(shortBucket?.avg_apr_pct ?? fallbackApr);
   const midApr = Number(midBucket?.avg_apr_pct ?? fallbackApr);

--- a/apps/web/src/components/data/data-page-client.tsx
+++ b/apps/web/src/components/data/data-page-client.tsx
@@ -97,6 +97,29 @@ interface PendingTrade {
   created_at: string;
 }
 
+interface SupplyOrder {
+  risk_grade: string;
+  apr_bucket: number;
+  lender_count: number;
+  available_volume: number;
+  avg_apr: number;
+  best_apr: number;
+  max_term_days: number;
+}
+
+interface MarketRate {
+  risk_grade: string;
+  ask_apr: number;
+  best_bid_apr: number;
+  weighted_avg_bid_apr: number;
+  spread: number;
+  demand_count: number;
+  demand_volume: number;
+  supply_count: number;
+  supply_volume: number;
+  liquidity_ratio: number | null;
+}
+
 interface RevenueSummary {
   total_fee_income: number;
   total_default_losses: number;
@@ -123,6 +146,8 @@ interface DataPageClientProps {
   yieldTrends: YieldTrendRow[];
   lenderConcentration: LenderConcRow[];
   pendingTrades: PendingTrade[];
+  supplyOrders: SupplyOrder[];
+  marketRates: MarketRate[];
   revenueSummary: RevenueSummary | null;
   revenueMonthly: RevenueMonthlyRow[];
 }
@@ -159,6 +184,8 @@ export function DataPageClient({
   yieldTrends,
   lenderConcentration,
   pendingTrades,
+  supplyOrders,
+  marketRates,
   revenueSummary,
   revenueMonthly,
 }: DataPageClientProps) {
@@ -192,7 +219,12 @@ export function DataPageClient({
         />
       )}
       {activeTab === "orderbook" && (
-        <OrderBookTab orderBook={orderBook} pendingTrades={pendingTrades} />
+        <OrderBookTab
+          orderBook={orderBook}
+          pendingTrades={pendingTrades}
+          supplyOrders={supplyOrders}
+          marketRates={marketRates}
+        />
       )}
       {activeTab === "performance" && (
         <PerformanceTab matchSpeed={matchSpeed} settlement={settlement} />
@@ -410,9 +442,13 @@ function OverviewTab({
 function OrderBookTab({
   orderBook,
   pendingTrades,
+  supplyOrders,
+  marketRates,
 }: {
   orderBook: OrderBookRow[];
   pendingTrades: PendingTrade[];
+  supplyOrders: SupplyOrder[];
+  marketRates: MarketRate[];
 }) {
   const [page, setPage] = useState(0);
   const PAGE_SIZE = 10;
@@ -429,17 +465,132 @@ function OrderBookTab({
     return h < 1 ? "<1h" : `${h}h`;
   }
 
+  // Aggregate supply by grade for summary
+  const supplyByGrade = new Map<string, { lenders: number; volume: number; bestApr: number; avgApr: number }>();
+  for (const s of supplyOrders) {
+    const existing = supplyByGrade.get(s.risk_grade);
+    if (existing) {
+      existing.lenders += s.lender_count;
+      existing.volume += s.available_volume;
+      existing.bestApr = Math.min(existing.bestApr, s.best_apr);
+    } else {
+      supplyByGrade.set(s.risk_grade, {
+        lenders: s.lender_count,
+        volume: s.available_volume,
+        bestApr: s.best_apr,
+        avgApr: s.avg_apr,
+      });
+    }
+  }
+
   return (
     <div className="space-y-4">
-      {/* Depth Chart */}
+      {/* Market Rate Cards */}
+      {marketRates.length > 0 && (
+        <div className="grid grid-cols-3 gap-3">
+          {["A", "B", "C"].map((grade) => {
+            const mr = marketRates.find((r) => r.risk_grade === grade);
+            if (!mr) return null;
+            const liquidityColor =
+              mr.liquidity_ratio != null && mr.liquidity_ratio >= 1
+                ? "success"
+                : mr.liquidity_ratio != null && mr.liquidity_ratio >= 0.5
+                  ? "warning"
+                  : "danger";
+            return (
+              <div key={grade} className="card-monzo p-3 space-y-1">
+                <div className="flex items-center justify-between">
+                  <GradeBadge grade={grade} />
+                  <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${
+                    liquidityColor === "success"
+                      ? "bg-success/10 text-success"
+                      : liquidityColor === "warning"
+                        ? "bg-warning/10 text-warning"
+                        : "bg-danger/10 text-danger"
+                  }`}>
+                    {mr.liquidity_ratio != null ? `${mr.liquidity_ratio.toFixed(1)}x` : "—"}
+                  </span>
+                </div>
+                <div className="grid grid-cols-2 gap-1 text-[10px]">
+                  <div>
+                    <span className="text-text-muted">Bid</span>
+                    <p className="font-bold text-success">{mr.best_bid_apr.toFixed(1)}%</p>
+                  </div>
+                  <div>
+                    <span className="text-text-muted">Ask</span>
+                    <p className="font-bold text-coral">{mr.ask_apr.toFixed(1)}%</p>
+                  </div>
+                </div>
+                <div className="text-[9px] text-text-muted">
+                  Spread: {mr.spread.toFixed(1)}% | {mr.supply_count} lenders
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Two-Sided Depth Chart */}
       <section className="card-monzo p-5 space-y-3">
-        <DepthChart pendingTrades={pendingTrades} />
+        <DepthChart pendingTrades={pendingTrades} supplyOrders={supplyOrders} />
       </section>
 
-      {/* Summary by Grade */}
+      {/* Supply Summary (Lender Standing Orders) */}
+      {supplyOrders.length > 0 && (
+        <section className="card-monzo p-5 space-y-3">
+          <h2 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
+            Supply (Lender Orders)
+          </h2>
+          <DataTable
+            columns={[
+              {
+                key: "grade",
+                header: "Grade",
+                render: (r: { grade: string; lenders: number; volume: number; bestApr: number }) => (
+                  <GradeBadge grade={r.grade} />
+                ),
+              },
+              {
+                key: "lenders",
+                header: "Lenders",
+                align: "right",
+                render: (r: { grade: string; lenders: number; volume: number; bestApr: number }) => (
+                  <span className="font-medium">{r.lenders}</span>
+                ),
+              },
+              {
+                key: "volume",
+                header: "Available",
+                align: "right",
+                render: (r: { grade: string; lenders: number; volume: number; bestApr: number }) =>
+                  fmtK(r.volume),
+              },
+              {
+                key: "apr",
+                header: "Best APR",
+                align: "right",
+                render: (r: { grade: string; lenders: number; volume: number; bestApr: number }) => (
+                  <span className="font-bold text-success">
+                    {r.bestApr.toFixed(1)}%
+                  </span>
+                ),
+              },
+            ]}
+            data={["A", "B", "C"]
+              .map((g) => {
+                const s = supplyByGrade.get(g);
+                return s ? { grade: g, ...s } : null;
+              })
+              .filter(Boolean) as { grade: string; lenders: number; volume: number; bestApr: number }[]}
+            emptyMessage="No lender supply data."
+          />
+        </section>
+      )}
+
+      {/* Demand Summary (Pending Trades by Grade) */}
       <section className="card-monzo p-5 space-y-3">
         <h2 className="text-xs font-semibold text-text-muted uppercase tracking-wider">
-          Pending by Grade
+          Demand (Pending Trades)
         </h2>
         <DataTable
           columns={[
@@ -469,7 +620,7 @@ function OrderBookTab({
               header: "Avg APR",
               align: "right",
               render: (r: OrderBookRow) => (
-                <span className="font-bold text-success">
+                <span className="font-bold text-coral">
                   {Number(r.avg_implied_apr_pct).toFixed(1)}%
                 </span>
               ),
@@ -528,7 +679,7 @@ function OrderBookTab({
                       100
                     : 0;
                 return (
-                  <span className="font-bold text-success">
+                  <span className="font-bold text-coral">
                     {apr.toFixed(1)}%
                   </span>
                 );
@@ -905,7 +1056,7 @@ function LendersTab({
     <div className="space-y-4">
       {/* Summary */}
       <div className="grid grid-cols-3 gap-3">
-        <StatCard label="Lenders" value={String(lenders.length)} />
+        <StatCard label="Lenders" value={String(totalPool > 0 ? lenders.length : 0)} />
         <StatCard
           label="HHI"
           value={hhi.toFixed(0)}

--- a/supabase/migrations/021_data_fixes_and_order_book.sql
+++ b/supabase/migrations/021_data_fixes_and_order_book.sql
@@ -1,0 +1,167 @@
+-- Migration 021: Data Quality Fixes + Order Book Supply Side
+--
+-- Sprint 1: Fix yield_curve (REPAID-only), matching_efficiency (use matched_at), yield_curve_agg
+-- Sprint 2: Add target_apr, order_book_supply, market_rates views
+
+-- =====================================================================
+-- SPRINT 1: DATA QUALITY FIXES
+-- =====================================================================
+
+-- 1a. Fix yield_curve: only include REPAID trades (was mixing LIVE/MATCHED)
+CREATE OR REPLACE VIEW public.yield_curve AS
+SELECT
+  risk_grade,
+  CASE
+    WHEN shift_days <= 7 THEN '0-7d'
+    WHEN shift_days <= 14 THEN '8-14d'
+    WHEN shift_days <= 30 THEN '15-30d'
+    ELSE '30d+'
+  END AS term_bucket,
+  count(*) AS trade_count,
+  ROUND(
+    AVG((fee / NULLIF(amount, 0)) * (365.0 / NULLIF(shift_days, 0)) * 100),
+    2
+  ) AS avg_apr_pct,
+  ROUND(AVG(fee), 2) AS avg_fee
+FROM trades
+WHERE status = 'REPAID'
+  AND amount > 0
+  AND shift_days > 0
+GROUP BY risk_grade, term_bucket;
+
+GRANT SELECT ON public.yield_curve TO authenticated;
+
+-- 1b. Aggregated yield curve: volume-weighted APR across all grades per term bucket
+CREATE OR REPLACE VIEW public.yield_curve_agg AS
+SELECT
+  term_bucket,
+  SUM(trade_count) AS trade_count,
+  ROUND(SUM(avg_apr_pct * trade_count) / NULLIF(SUM(trade_count), 0), 2) AS avg_apr_pct,
+  ROUND(SUM(avg_fee * trade_count) / NULLIF(SUM(trade_count), 0), 2) AS avg_fee
+FROM yield_curve
+GROUP BY term_bucket;
+
+GRANT SELECT ON public.yield_curve_agg TO authenticated;
+
+-- 1c. Fix matching_efficiency: use matched_at instead of updated_at for accurate match speed
+CREATE OR REPLACE VIEW public.matching_efficiency AS
+SELECT
+  risk_grade,
+  count(*) FILTER (WHERE status IN ('MATCHED', 'LIVE', 'REPAID')) AS matched_count,
+  count(*) FILTER (WHERE status = 'PENDING_MATCH') AS pending_count,
+  ROUND(
+    count(*) FILTER (WHERE status IN ('MATCHED', 'LIVE', 'REPAID'))::numeric
+    / NULLIF(count(*), 0),
+    4
+  ) AS fill_rate,
+  ROUND((
+    AVG(
+      EXTRACT(EPOCH FROM (matched_at - created_at)) / 3600
+    ) FILTER (WHERE status IN ('MATCHED', 'LIVE', 'REPAID') AND matched_at IS NOT NULL)
+  )::numeric, 4) AS avg_hours_to_match,
+  ROUND((
+    PERCENTILE_CONT(0.5) WITHIN GROUP (
+      ORDER BY EXTRACT(EPOCH FROM (matched_at - created_at)) / 3600
+    ) FILTER (WHERE status IN ('MATCHED', 'LIVE', 'REPAID') AND matched_at IS NOT NULL)
+  )::numeric, 4) AS median_hours_to_match,
+  ROUND((
+    MIN(
+      EXTRACT(EPOCH FROM (matched_at - created_at)) / 3600
+    ) FILTER (WHERE status IN ('MATCHED', 'LIVE', 'REPAID') AND matched_at IS NOT NULL)
+  )::numeric, 4) AS fastest_match_hours,
+  ROUND((
+    MAX(
+      EXTRACT(EPOCH FROM (matched_at - created_at)) / 3600
+    ) FILTER (WHERE status IN ('MATCHED', 'LIVE', 'REPAID') AND matched_at IS NOT NULL)
+  )::numeric, 4) AS slowest_match_hours
+FROM trades
+GROUP BY risk_grade;
+
+GRANT SELECT ON public.matching_efficiency TO authenticated;
+
+-- =====================================================================
+-- SPRINT 2: ORDER BOOK SUPPLY SIDE
+-- =====================================================================
+
+-- 2a. Add target_apr to lender_preferences (the rate lenders WANT to earn)
+ALTER TABLE public.lender_preferences
+  ADD COLUMN IF NOT EXISTS target_apr numeric(6,2) DEFAULT NULL;
+
+COMMENT ON COLUMN public.lender_preferences.target_apr IS
+  'Lender desired APR (offer rate). If null, uses min_apr. Posted on supply side of order book.';
+
+-- 2b. Supply-side order book: lender standing orders aggregated by grade + APR bucket
+CREATE OR REPLACE VIEW public.order_book_supply AS
+SELECT
+  rb::text AS risk_grade,
+  (FLOOR(COALESCE(lp_pref.target_apr, lp_pref.min_apr) / 0.5) * 0.5) AS apr_bucket,
+  COUNT(*) AS lender_count,
+  ROUND(SUM(
+    LEAST(
+      pot.available,
+      lp_pref.max_exposure,
+      GREATEST(lp_pref.max_total_exposure - COALESCE(exposure.current_exposure, 0), 0)
+    )
+  ), 2) AS available_volume,
+  ROUND(AVG(COALESCE(lp_pref.target_apr, lp_pref.min_apr)), 2) AS avg_apr,
+  ROUND(MIN(COALESCE(lp_pref.target_apr, lp_pref.min_apr)), 2) AS best_apr,
+  MAX(lp_pref.max_shift_days) AS max_term_days
+FROM public.lender_preferences lp_pref
+CROSS JOIN LATERAL UNNEST(lp_pref.risk_bands) AS t(rb)
+JOIN public.lending_pots pot ON pot.user_id = lp_pref.user_id
+LEFT JOIN LATERAL (
+  SELECT COALESCE(SUM(a.amount_slice), 0) AS current_exposure
+  FROM public.allocations a
+  WHERE a.lender_id = lp_pref.user_id
+    AND a.status IN ('RESERVED', 'ACTIVE')
+) exposure ON TRUE
+WHERE lp_pref.auto_match_enabled = true
+  AND pot.available > 0
+  AND NOT COALESCE(pot.withdrawal_queued, false)
+GROUP BY rb, (FLOOR(COALESCE(lp_pref.target_apr, lp_pref.min_apr) / 0.5) * 0.5)
+ORDER BY rb, apr_bucket;
+
+GRANT SELECT ON public.order_book_supply TO authenticated;
+
+-- 2c. Market rates: per-grade bid/ask spread + liquidity ratio
+CREATE OR REPLACE VIEW public.market_rates AS
+SELECT
+  d.risk_grade::text AS risk_grade,
+  -- Ask: use pre-computed implied APR from order_book_depth
+  COALESCE(d.avg_implied_apr_pct, 0)::numeric AS ask_apr,
+  -- Bid: best (lowest) and weighted avg APR from supply
+  COALESCE(s.best_bid_apr, 0) AS best_bid_apr,
+  COALESCE(s.weighted_avg_bid_apr, 0) AS weighted_avg_bid_apr,
+  -- Spread
+  ROUND((COALESCE(d.avg_implied_apr_pct, 0) - COALESCE(s.best_bid_apr, 0))::numeric, 2) AS spread,
+  d.trade_count AS demand_count,
+  d.total_amount AS demand_volume,
+  COALESCE(s.lender_count, 0)::bigint AS supply_count,
+  COALESCE(s.supply_volume, 0) AS supply_volume,
+  -- Liquidity ratio: supply / demand (>1 = liquid)
+  CASE WHEN d.total_amount > 0
+    THEN ROUND(COALESCE(s.supply_volume, 0) / d.total_amount, 2)
+    ELSE NULL
+  END AS liquidity_ratio
+FROM public.order_book_depth d
+LEFT JOIN (
+  SELECT
+    risk_grade,
+    MIN(avg_apr) AS best_bid_apr,
+    ROUND(SUM(avg_apr * available_volume) / NULLIF(SUM(available_volume), 0), 2) AS weighted_avg_bid_apr,
+    SUM(lender_count) AS lender_count,
+    SUM(available_volume) AS supply_volume
+  FROM public.order_book_supply
+  GROUP BY risk_grade
+) s ON s.risk_grade = d.risk_grade::text;
+
+GRANT SELECT ON public.market_rates TO authenticated;
+
+-- 2d. Indexes for order book performance
+CREATE INDEX IF NOT EXISTS idx_lender_prefs_auto_match
+  ON public.lender_preferences (auto_match_enabled)
+  WHERE auto_match_enabled = true;
+
+CREATE INDEX IF NOT EXISTS idx_lending_pots_available
+  ON public.lending_pots (user_id, available)
+  WHERE available > 0;


### PR DESCRIPTION
## Summary
- Fixed yield curve (REPAID-only, volume-weighted aggregation across grades)
- Fixed lender count discrepancy (255 vs 25)
- Fixed match speed display (uses matched_at, realistic seed times)
- Added two-sided order book: supply (lender standing orders) + demand (pending trades)
- Added market-based fee pricing in generate-proposals Edge Function
- Added platform revenue tracking (80/20 fee split, monthly breakdown)

## Changes
- **Migration 021**: yield_curve fix, yield_curve_agg, matching_efficiency fix, order_book_supply, market_rates, target_apr column
- **depth-chart.tsx**: Rewritten for bid/ask overlay with market clearing point
- **data-page-client.tsx**: Market rate cards, supply table, updated OrderBookTab
- **data/page.tsx**: Removed .limit(25), added supply/market queries
- **lender/page.tsx**: Uses yield_curve_agg (fixes random grade selection bug)
- **generate-proposals**: Market-aware fee pricing (bid-ask midpoint when liquid)
- **seed.ts**: Realistic match times (70% <30s), target_apr, platform_revenue entries

## Test plan
- [x] `pnpm build` passes
- [x] Migrations 020+021 applied to Supabase
- [x] Database re-seeded (705 platform revenue entries, 255 lenders, realistic match times)
- [x] Yield curve shows consistent ~7% APR across 0-7d and 8-14d buckets
- [x] Market rates view shows bid/ask/spread per grade with liquidity ratios
- [x] Order book supply shows 381 lenders across A/B/C with £76k supply
- [x] Platform fee split verified: 20.4% platform / 79.6% lender
- [x] All E2E verification queries pass

See #78 for Member C handoff details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)