### PR TITLE
feat: integrate quant_analysis ML backend into UI surfaces

### DIFF
--- a/apps/web/src/components/borrower/upcoming-transactions.tsx
+++ b/apps/web/src/components/borrower/upcoming-transactions.tsx
@@ -106,7 +106,9 @@ export function UpcomingTransactions({ items }: UpcomingTransactionsProps) {
         {sorted.map((item) => (
           <div
             key={item.id}
-            className="flex items-center gap-3 py-2.5 border-b border-warm-grey last:border-0"
+            className={`flex items-center gap-3 py-2.5 border-b border-warm-grey last:border-0 ${
+              item.category === "estimated" ? "opacity-50" : ""
+            }`}
           >
             {/* Date */}
             <div className="w-12 text-center shrink-0">
@@ -120,21 +122,23 @@ export function UpcomingTransactions({ items }: UpcomingTransactionsProps) {
 
             {/* Name + subtitle */}
             <div className="flex-1 min-w-0">
-              <p className="text-sm font-medium text-navy truncate">
-                {item.name}
+              <p className={`text-sm font-medium truncate ${item.category === "estimated" ? "text-text-secondary italic" : "text-navy"}`}>
+                {item.category === "estimated" ? `~${item.name}` : item.name}
               </p>
               <p className="text-[10px] text-text-muted">
-                {item.type === "income" && "Income"}
-                {item.type === "repayment" && "Auto-repayment"}
-                {item.type === "bill" && frequencyLabel(item.frequency ?? "MONTHLY")}
+                {item.category === "estimated" && "Estimated"}
+                {item.category !== "estimated" && item.type === "income" && "Income"}
+                {item.category !== "estimated" && item.type === "repayment" && "Auto-repayment"}
+                {item.category !== "estimated" && item.type === "bill" && frequencyLabel(item.frequency ?? "MONTHLY")}
               </p>
             </div>
 
             {/* Amount */}
-            <p className={`text-sm font-bold shrink-0 ${
-              item.type === "income" ? "text-success" : item.type === "repayment" ? "text-coral" : "text-navy"
+            <p className={`text-sm shrink-0 ${
+              item.category === "estimated" ? "text-text-muted font-medium" :
+              item.type === "income" ? "text-success font-bold" : item.type === "repayment" ? "text-coral font-bold" : "text-navy font-bold"
             }`}>
-              {item.type === "income" ? "+" : "-"}{formatCurrency(item.amount_pence)}
+              {item.type === "income" ? "+" : item.category === "estimated" ? "~" : "-"}{formatCurrency(item.amount_pence)}
             </p>
 
           </div>

--- a/apps/web/src/components/data/forecast-accuracy.tsx
+++ b/apps/web/src/components/data/forecast-accuracy.tsx
@@ -129,7 +129,7 @@ export function ForecastAccuracy({ data }: ForecastAccuracyProps) {
             fontSize={7}
             fill="var(--text-muted)"
           >
-            {data.days[idx]?.slice(5) ?? ""}
+            Day {data.days[idx] ?? ""}
           </text>
         ))}
 

--- a/apps/web/src/components/data/portfolio-returns.tsx
+++ b/apps/web/src/components/data/portfolio-returns.tsx
@@ -25,10 +25,10 @@ export function PortfolioReturns({ data }: PortfolioReturnsProps) {
   const pad = { left: 80, right: 20, top: 10, bottom: 10 };
   const barH = 18;
   const chartW = W - pad.left - pad.right;
-  const maxVal = Math.max(data.weighted_yield, data.risk_free_rate, 0.01);
+  const maxVal = Math.max(data.weighted_yield_pct, data.risk_free_rate_pct, 0.01);
 
-  const portfolioW = (data.weighted_yield / maxVal) * chartW;
-  const riskFreeW = (data.risk_free_rate / maxVal) * chartW;
+  const portfolioW = (data.weighted_yield_pct / maxVal) * chartW;
+  const riskFreeW = (data.risk_free_rate_pct / maxVal) * chartW;
 
   return (
     <section id="returns" className="card-monzo p-5 space-y-4">
@@ -60,25 +60,25 @@ export function PortfolioReturns({ data }: PortfolioReturnsProps) {
         <div className="bg-warm-grey/30 rounded-xl p-3">
           <p className="text-xs text-text-muted">Weighted Yield</p>
           <p className="text-lg font-bold text-navy mt-0.5">
-            {(data.weighted_yield * 100).toFixed(2)}%
+            {(data.weighted_yield_pct * 100).toFixed(2)}%
           </p>
         </div>
         <div className="bg-warm-grey/30 rounded-xl p-3">
           <p className="text-xs text-text-muted">Risk-Free Rate</p>
           <p className="text-lg font-bold text-navy mt-0.5">
-            {(data.risk_free_rate * 100).toFixed(2)}%
+            {(data.risk_free_rate_pct * 100).toFixed(2)}%
           </p>
         </div>
         <div className="bg-warm-grey/30 rounded-xl p-3">
           <p className="text-xs text-text-muted">Excess Return</p>
-          <p className={`text-lg font-bold mt-0.5 ${data.excess_return >= 0 ? "text-success" : "text-danger"}`}>
-            {data.excess_return >= 0 ? "+" : ""}{(data.excess_return * 100).toFixed(2)}%
+          <p className={`text-lg font-bold mt-0.5 ${data.excess_return_pct >= 0 ? "text-success" : "text-danger"}`}>
+            {data.excess_return_pct >= 0 ? "+" : ""}{(data.excess_return_pct * 100).toFixed(2)}%
           </p>
         </div>
         <div className="bg-warm-grey/30 rounded-xl p-3">
           <p className="text-xs text-text-muted">Total Capital</p>
           <p className="text-lg font-bold text-navy mt-0.5">
-            {"\u00A3"}{data.total_capital.toFixed(2)}
+            {"\u00A3"}{data.total_capital_gbp.toFixed(2)}
           </p>
         </div>
       </div>
@@ -91,7 +91,7 @@ export function PortfolioReturns({ data }: PortfolioReturnsProps) {
         </text>
         <rect x={pad.left} y={pad.top} width={Math.max(portfolioW, 2)} height={barH} rx={4} fill="var(--coral)" opacity={0.85} />
         <text x={pad.left + portfolioW + 6} y={pad.top + barH / 2 + 4} fontSize={9} fontWeight="bold" fill="var(--coral)">
-          {(data.weighted_yield * 100).toFixed(1)}%
+          {(data.weighted_yield_pct * 100).toFixed(1)}%
         </text>
 
         {/* Risk-free bar */}
@@ -100,7 +100,7 @@ export function PortfolioReturns({ data }: PortfolioReturnsProps) {
         </text>
         <rect x={pad.left} y={pad.top + barH + 16} width={Math.max(riskFreeW, 2)} height={barH} rx={4} fill="var(--text-muted)" opacity={0.5} />
         <text x={pad.left + riskFreeW + 6} y={pad.top + barH + 16 + barH / 2 + 4} fontSize={9} fontWeight="bold" fill="var(--text-muted)">
-          {(data.risk_free_rate * 100).toFixed(1)}%
+          {(data.risk_free_rate_pct * 100).toFixed(1)}%
         </text>
       </svg>
 
@@ -109,7 +109,7 @@ export function PortfolioReturns({ data }: PortfolioReturnsProps) {
         <p className="text-xs text-text-secondary">
           The portfolio earns{" "}
           <span className="font-bold text-success">
-            {(data.excess_return * 100).toFixed(1)}%
+            {(data.excess_return_pct * 100).toFixed(1)}%
           </span>{" "}
           above the risk-free rate, with a risk-adjusted Sharpe ratio of{" "}
           <span className={`font-bold ${sharpeColor}`}>{data.sharpe_ratio.toFixed(2)}</span>.

--- a/apps/web/src/lib/quant-api.ts
+++ b/apps/web/src/lib/quant-api.ts
@@ -32,10 +32,10 @@ export interface BacktestResponse {
 
 export interface ReturnsResponse {
   sharpe_ratio: number;
-  weighted_yield: number;
-  risk_free_rate: number;
-  excess_return: number;
-  total_capital: number;
+  weighted_yield_pct: number;
+  risk_free_rate_pct: number;
+  excess_return_pct: number;
+  total_capital_gbp: number;
 }
 
 export interface EdaFeatureStats {
@@ -52,10 +52,36 @@ export interface EdaResponse {
 }
 
 export interface ForecastAccuracyResponse {
-  days: string[];
+  days: number[];
   actual: number[];
   forecasted: number[];
   mape_pct: number;
+}
+
+// --- Spending forecast types (used by Edge Function, not called from frontend directly) ---
+
+export interface SpendingForecastRequest {
+  user_id: string;
+  transactions: {
+    date: string;
+    amount: number;
+    category?: string;
+  }[];
+  horizon_days?: number;
+}
+
+export interface DailyForecast {
+  date: string;
+  expected_pence: number;
+  confidence_low_pence: number;
+  confidence_high_pence: number;
+  model_tier: "gamma_dow" | "gamma_flat" | "fallback_flat";
+}
+
+export interface SpendingForecastResponse {
+  user_id: string;
+  forecasts: DailyForecast[];
+  model_tier: string;
 }
 
 export interface LenderStats {


### PR DESCRIPTION
## Summary
- **Fix type mismatches** in `quant-api.ts`: `ReturnsResponse` fields corrected with `_pct`/`_gbp` suffixes, `ForecastAccuracyResponse.days` fixed from `string[]` to `number[]`
- **Update consuming components**: `portfolio-returns.tsx`, `forecast-accuracy.tsx`, and `quant-dashboard.tsx` updated to use corrected field names
- **Add SpendingForecast types** (`SpendingForecastRequest`, `DailyForecast`, `SpendingForecastResponse`) to `quant-api.ts`
- **Display risk_grade badge** (A=green, B=amber, C=red pill) on borrower dashboard balance card
- **Add "Everyday Spending"** estimated rows to cashflow timeline when forecast outgoings exceed scheduled bills
- **Add simulated liquidity pool** section to ML/Quant tab — fetches `GET /api/quant/lenders` and shows total capital, deployed/available breakdown, average target APR, and top lender table

## Test plan
- [ ] Verify `/data` ML/Quant tab loads all 6 sub-sections without crashes
- [ ] Verify Portfolio Returns section shows corrected field names (weighted_yield_pct, etc.)
- [ ] Verify Forecast Accuracy chart renders with numeric day labels
- [ ] Verify new "Liquidity Pool" sub-tab shows simulated lender data
- [ ] Verify borrower dashboard shows risk grade badge (A/B/C) when profile has risk_grade
- [ ] Verify cashflow timeline shows dimmed "~Everyday spending" rows for forecast days with irregular outgoings
- [ ] Verify no runtime errors when `QUANT_API_URL` is unset (graceful null handling)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)