### PR TITLE
feat: production-ready data overhaul + ML/Quant + Claude agent

### DIFF
--- a/apps/web/src/app/api/claude/insights/route.ts
+++ b/apps/web/src/app/api/claude/insights/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+import { callClaude } from "@/lib/claude/client";
+import {
+  FINANCIAL_INSIGHTS_SYSTEM,
+  buildFinancialInsightsPrompt,
+} from "@/lib/claude/prompts";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const {
+      riskGrade,
+      creditScore,
+      dangerDays,
+      obligations,
+      avgBalance_pence,
+      incomePattern,
+    } = body;
+
+    if (!riskGrade) {
+      return NextResponse.json(
+        { error: "riskGrade is required" },
+        { status: 400 },
+      );
+    }
+
+    const prompt = buildFinancialInsightsPrompt({
+      riskGrade,
+      creditScore: creditScore ?? 650,
+      dangerDays: dangerDays ?? 0,
+      obligations: obligations ?? [],
+      avgBalance_pence: avgBalance_pence ?? 0,
+      incomePattern: incomePattern ?? "monthly salary",
+    });
+
+    const insight = await callClaude(
+      FINANCIAL_INSIGHTS_SYSTEM,
+      [{ role: "user", content: prompt }],
+      400,
+    );
+
+    return NextResponse.json({ insight });
+  } catch (error) {
+    console.error("Financial insights error:", error);
+    return NextResponse.json(
+      { error: "Failed to generate insights" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/claude/risk-explain/route.ts
+++ b/apps/web/src/app/api/claude/risk-explain/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { callClaude } from "@/lib/claude/client";
+import {
+  RISK_EXPLAINER_SYSTEM,
+  buildRiskExplainPrompt,
+} from "@/lib/claude/prompts";
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = await req.json();
+    const { creditScore, riskGrade, shapValues } = body;
+
+    if (!creditScore || !riskGrade) {
+      return NextResponse.json(
+        { error: "creditScore and riskGrade are required" },
+        { status: 400 },
+      );
+    }
+
+    const prompt = buildRiskExplainPrompt({
+      creditScore,
+      riskGrade,
+      shapValues: shapValues ?? [],
+    });
+
+    const explanation = await callClaude(
+      RISK_EXPLAINER_SYSTEM,
+      [{ role: "user", content: prompt }],
+      300,
+    );
+
+    return NextResponse.json({ explanation });
+  } catch (error) {
+    console.error("Risk explain error:", error);
+    return NextResponse.json(
+      { error: "Failed to generate risk explanation" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/components/data/depth-chart.tsx
+++ b/apps/web/src/components/data/depth-chart.tsx
@@ -37,7 +37,7 @@ const GRADE_COLORS: Record<string, { fill: string; stroke: string; label: string
 
 const BID_COLOR = { fill: "rgba(59, 130, 246, 0.2)", stroke: "#3B82F6" };
 
-const BUCKET_WIDTH = 50; // 50% APR buckets
+const BUCKET_WIDTH = 2; // 2% APR buckets for granularity
 
 export function DepthChart({ pendingTrades, supplyOrders = [] }: DepthChartProps) {
   const [hoveredBucket, setHoveredBucket] = useState<{
@@ -109,8 +109,8 @@ export function DepthChart({ pendingTrades, supplyOrders = [] }: DepthChartProps
     const askAprs = allBuckets.map((b) => b.aprBucket);
     const bidAprs = bidCumAsc.map((b) => b.apr);
     const allAprs = [...askAprs, ...bidAprs];
-    const minApr = Math.min(...allAprs, 0);
-    const maxApr = Math.max(...allAprs, 500) + BUCKET_WIDTH;
+    const minApr = Math.max(Math.min(...allAprs, 0), 0);
+    const maxApr = Math.min(Math.max(...allAprs, 20) + BUCKET_WIDTH, 50);
 
     // Build cumulative ask volume per grade (ascending by APR)
     const grades = ["A", "B", "C"];

--- a/apps/web/src/components/data/quant-dashboard.tsx
+++ b/apps/web/src/components/data/quant-dashboard.tsx
@@ -6,10 +6,8 @@ import { DataTable, GradeBadge } from "./data-table";
 
 interface BacktestRow {
   grade: string;
-  total: number;
-  defaulted: number;
   default_rate: number;
-  avg_score: number;
+  n_borrowers: number;
 }
 
 interface PortfolioReturns {
@@ -21,8 +19,8 @@ interface PortfolioReturns {
 }
 
 interface EdaStats {
-  summary: Record<string, { mean: number; std: number; min: number; max: number }>;
-  correlations: Record<string, Record<string, number>>;
+  summary: Record<string, { mean: number; std: number; median?: number; min?: number; max?: number }>;
+  correlation: Record<string, Record<string, number>>;
 }
 
 interface ForecastAccuracy {
@@ -60,9 +58,11 @@ export function QuantDashboard() {
   const [eda, setEda] = useState<EdaStats | null>(null);
   const [forecast, setForecast] = useState<ForecastAccuracy | null>(null);
   const [stressResult, setStressResult] = useState<{
-    base_score: number;
+    original_score: number;
     stressed_score: number;
-    delta: number;
+    score_delta: number;
+    original_grade: string;
+    stressed_grade: string;
   } | null>(null);
   const [stressMultiplier, setStressMultiplier] = useState(0.7);
   const [lenders, setLenders] = useState<LendersData | null>(null);
@@ -79,7 +79,15 @@ export function QuantDashboard() {
           if (!res.ok) throw new Error("Failed to fetch backtest");
           const data = await res.json();
           if (!data.backtest || typeof data.backtest !== "object") throw new Error("Invalid backtest response");
-          setBacktest(Array.isArray(data.backtest) ? data.backtest : Object.entries(data.backtest).map(([grade, stats]) => ({ grade, ...(stats as Record<string, unknown>) })));
+          const bt = data.backtest;
+          const rows: BacktestRow[] = Array.isArray(bt)
+            ? bt
+            : Object.entries(bt).map(([grade, stats]) => ({
+                grade,
+                default_rate: (stats as { default_rate: number }).default_rate ?? 0,
+                n_borrowers: (stats as { n_borrowers: number }).n_borrowers ?? 0,
+              }));
+          setBacktest(rows);
           break;
         }
         case "returns": {
@@ -97,7 +105,11 @@ export function QuantDashboard() {
           if (!res.ok) throw new Error("Failed to fetch EDA");
           const data = await res.json();
           if (data.error) throw new Error(data.error);
-          setEda(data);
+          // Backend uses "correlation" not "correlations"
+          setEda({
+            summary: data.summary ?? {},
+            correlation: data.correlation ?? data.correlations ?? {},
+          });
           break;
         }
         case "forecast": {
@@ -245,18 +257,12 @@ function BacktestSection({ data }: { data: BacktestRow[] }) {
             render: (r: BacktestRow) => <GradeBadge grade={r.grade} />,
           },
           {
-            key: "total",
+            key: "n_borrowers",
             header: "Sample",
             align: "right",
             render: (r: BacktestRow) => (
-              <span className="font-medium">{r.total}</span>
+              <span className="font-medium">{r.n_borrowers.toLocaleString()}</span>
             ),
-          },
-          {
-            key: "defaulted",
-            header: "Defaults",
-            align: "right",
-            render: (r: BacktestRow) => r.defaulted,
           },
           {
             key: "rate",
@@ -265,18 +271,12 @@ function BacktestSection({ data }: { data: BacktestRow[] }) {
             render: (r: BacktestRow) => (
               <span
                 className={
-                  r.default_rate > 10 ? "text-danger font-bold" : "text-navy"
+                  r.default_rate > 0.10 ? "text-danger font-bold" : "text-navy"
                 }
               >
-                {(r.default_rate * 100).toFixed(1)}%
+                {(r.default_rate * 100).toFixed(2)}%
               </span>
             ),
-          },
-          {
-            key: "score",
-            header: "Avg Score",
-            align: "right",
-            render: (r: BacktestRow) => r.avg_score?.toFixed(0) ?? "—",
           },
         ]}
         data={data}
@@ -286,13 +286,17 @@ function BacktestSection({ data }: { data: BacktestRow[] }) {
 }
 
 function ReturnsSection({ data }: { data: PortfolioReturns }) {
+  const fmtGBP = (v: number) => v >= 1000000
+    ? `£${(v / 1000000).toFixed(1)}M`
+    : v >= 1000 ? `£${(v / 1000).toFixed(0)}k` : `£${v.toFixed(2)}`;
+
   return (
     <div className="space-y-3">
       <h3 className="text-sm font-bold text-navy">Portfolio Returns</h3>
       <div className="grid grid-cols-2 gap-3">
         <StatCard
           label="Weighted Yield"
-          value={`${((data.weighted_yield_pct ?? 0) * 100).toFixed(2)}%`}
+          value={`${(data.weighted_yield_pct ?? 0).toFixed(2)}%`}
           variant="success"
         />
         <StatCard
@@ -301,17 +305,17 @@ function ReturnsSection({ data }: { data: PortfolioReturns }) {
         />
         <StatCard
           label="Risk-Free Rate"
-          value={`${((data.risk_free_rate_pct ?? 0) * 100).toFixed(2)}%`}
+          value={`${(data.risk_free_rate_pct ?? 0).toFixed(2)}%`}
         />
         <StatCard
           label="Excess Return"
-          value={`${data.excess_return_pct >= 0 ? "+" : ""}${((data.excess_return_pct ?? 0) * 100).toFixed(2)}%`}
-          variant={data.excess_return_pct >= 0 ? "success" : "danger"}
+          value={`${(data.excess_return_pct ?? 0) >= 0 ? "+" : ""}${(data.excess_return_pct ?? 0).toFixed(2)}%`}
+          variant={(data.excess_return_pct ?? 0) >= 0 ? "success" : "danger"}
         />
       </div>
       <StatCard
         label="Total Capital"
-        value={`£${(data.total_capital_gbp ?? 0).toFixed(2)}`}
+        value={fmtGBP(data.total_capital_gbp ?? 0)}
       />
     </div>
   );
@@ -327,7 +331,7 @@ function EdaSection({ data }: { data: EdaStats }) {
           {
             key: "feature",
             header: "Feature",
-            render: (r: [string, { mean: number; std: number; min: number; max: number }]) => (
+            render: (r: [string, { mean: number; std: number; median?: number }]) => (
               <span className="text-xs">{r[0].replace(/_/g, " ")}</span>
             ),
           },
@@ -338,28 +342,27 @@ function EdaSection({ data }: { data: EdaStats }) {
             render: (r: [string, { mean: number }]) => r[1].mean?.toFixed(2),
           },
           {
+            key: "median",
+            header: "Median",
+            align: "right",
+            render: (r: [string, { median?: number }]) => r[1].median?.toFixed(2) ?? "—",
+          },
+          {
             key: "std",
             header: "Std",
             align: "right",
             render: (r: [string, { std: number }]) => r[1].std?.toFixed(2),
           },
-          {
-            key: "range",
-            header: "Range",
-            align: "right",
-            render: (r: [string, { min: number; max: number }]) =>
-              `${r[1].min?.toFixed(1)} – ${r[1].max?.toFixed(1)}`,
-          },
         ]}
         data={features}
       />
 
-      {data.correlations && (
+      {data.correlation && Object.keys(data.correlation).length > 0 && (
         <>
           <h3 className="text-sm font-bold text-navy mt-4">
             Correlation Matrix
           </h3>
-          <CorrelationHeatmap correlations={data.correlations} />
+          <CorrelationHeatmap correlations={data.correlation} />
         </>
       )}
     </div>
@@ -572,7 +575,7 @@ function StressSection({
   onMultiplierChange,
   onRun,
 }: {
-  result: { base_score: number; stressed_score: number; delta: number } | null;
+  result: { original_score: number; stressed_score: number; score_delta: number; original_grade: string; stressed_grade: string } | null;
   multiplier: number;
   onMultiplierChange: (m: number) => void;
   onRun: () => void;
@@ -611,24 +614,31 @@ function StressSection({
       </button>
 
       {result && (
-        <div className="grid grid-cols-3 gap-3 mt-2">
-          <StatCard label="Base Score" value={result.base_score?.toFixed(0) ?? "—"} />
-          <StatCard
-            label="Stressed Score"
-            value={result.stressed_score?.toFixed(0) ?? "—"}
-            variant={
-              result.stressed_score < 500
-                ? "danger"
-                : result.stressed_score < 650
-                  ? "warning"
-                  : "default"
-            }
-          />
-          <StatCard
-            label="Delta"
-            value={`${result.delta > 0 ? "+" : ""}${result.delta?.toFixed(0) ?? "—"}`}
-            variant={result.delta < -50 ? "danger" : "default"}
-          />
+        <div className="space-y-3 mt-2">
+          <div className="grid grid-cols-3 gap-3">
+            <StatCard
+              label="Base Score"
+              value={result.original_score?.toFixed(0) ?? "—"}
+              subtitle={`Grade ${result.original_grade}`}
+            />
+            <StatCard
+              label="Stressed Score"
+              value={result.stressed_score?.toFixed(0) ?? "—"}
+              subtitle={`Grade ${result.stressed_grade}`}
+              variant={
+                result.stressed_score < 500
+                  ? "danger"
+                  : result.stressed_score < 650
+                    ? "warning"
+                    : "default"
+              }
+            />
+            <StatCard
+              label="Delta"
+              value={`${result.score_delta > 0 ? "+" : ""}${result.score_delta?.toFixed(0) ?? "—"}`}
+              variant={result.score_delta < -50 ? "danger" : "default"}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/apps/web/src/lib/claude/prompts.ts
+++ b/apps/web/src/lib/claude/prompts.ts
@@ -25,6 +25,61 @@ Keep it simple, friendly, and under 3 sentences. Don't say "I recommend" — exp
 
 export const FORECAST_EXPLANATION_SYSTEM = `You are Flowzo's AI assistant. You summarise cash flow forecasts in plain, friendly English. Be brief (2-3 sentences). Use GBP currency. Never give financial advice.`;
 
+export const FINANCIAL_INSIGHTS_SYSTEM = `You are Flowzo's AI financial insights assistant. You analyse a borrower's financial data and provide 2-3 actionable observations about their cash flow patterns, bill timing, and risk profile. Be conversational and specific — reference actual numbers. Use GBP. Never give regulated financial advice. Focus on practical timing and budgeting insights.`;
+
+export function buildFinancialInsightsPrompt(params: {
+  riskGrade: string;
+  creditScore: number;
+  dangerDays: number;
+  obligations: { name: string; amount_pence: number; expected_day: number }[];
+  avgBalance_pence: number;
+  incomePattern: string;
+}): string {
+  const obligations = params.obligations
+    .map((o) => `${o.name}: £${(o.amount_pence / 100).toFixed(2)} due day ${o.expected_day}`)
+    .join(", ");
+
+  return `Analyse this borrower's financial profile and give 2-3 specific, actionable insights:
+
+Risk Grade: ${params.riskGrade} | Credit Score: ${params.creditScore}
+Danger days (shortfall risk): ${params.dangerDays} in next 30 days
+Average balance: £${(params.avgBalance_pence / 100).toFixed(2)}
+Income pattern: ${params.incomePattern}
+Bills: ${obligations}
+
+Focus on bill timing clusters, income-expense alignment, and practical suggestions. Be specific about which bills and dates.`;
+}
+
+export const RISK_EXPLAINER_SYSTEM = `You are Flowzo's AI risk analyst. You explain credit risk scores using SHAP feature importance in plain English. Be brief (2-3 sentences). Explain which factors help and hurt the score. Use specific numbers. Never give financial advice.`;
+
+export function buildRiskExplainPrompt(params: {
+  creditScore: number;
+  riskGrade: string;
+  shapValues: { feature: string; value: number; impact: number }[];
+}): string {
+  const topPositive = params.shapValues
+    .filter((s) => s.impact > 0)
+    .sort((a, b) => b.impact - a.impact)
+    .slice(0, 3)
+    .map((s) => `${s.feature.replace(/_/g, " ")}: +${s.impact.toFixed(1)}`)
+    .join(", ");
+
+  const topNegative = params.shapValues
+    .filter((s) => s.impact < 0)
+    .sort((a, b) => a.impact - b.impact)
+    .slice(0, 3)
+    .map((s) => `${s.feature.replace(/_/g, " ")}: ${s.impact.toFixed(1)}`)
+    .join(", ");
+
+  return `Explain this credit risk assessment to the user:
+
+Score: ${params.creditScore} (Grade ${params.riskGrade})
+Positive factors: ${topPositive || "none"}
+Negative factors: ${topNegative || "none"}
+
+Explain what drives their score in 2-3 sentences. Be encouraging but honest.`;
+}
+
 export function buildForecastSummaryPrompt(params: {
   dangerDays: number;
   lowestBalancePence: number;

--- a/supabase/functions/generate-proposals/index.ts
+++ b/supabase/functions/generate-proposals/index.ts
@@ -25,7 +25,8 @@ function calculateFee(
   riskGrade: string,
 ): number {
   const riskMult = RISK_MULTIPLIERS[riskGrade] ?? 1.5;
-  const rawFee = BASE_RATE * amount * (shiftDays / 365) * riskMult;
+  const termPremium = 1 + (shiftDays / 14) * 0.15; // +15% per 14-day period
+  const rawFee = BASE_RATE * amount * (shiftDays / 365) * riskMult * termPremium;
   const cap = Math.min(amount * 0.05, 10.0); // GBP 10 cap
   const fee = Math.min(rawFee, cap);
   return Math.round(Math.max(fee, 0.01) * 100) / 100;


### PR DESCRIPTION
## Summary
- 10x seed data (10K trades), realistic pricing with term premium, sub-10s match speed
- Order book depth chart now shows 0-50% APR with 2% granularity
- ML/Quant tab fully working — fixed API response field mapping for Railway backend
- Claude agent: new financial insights + risk explainer API routes

## Changes

### Seed Data (10K trades)
- `TRADE_COUNT`: 1,050 → 10,000
- `min_apr`: randomFloat(2, 8) — no more 0% bids
- Term premium: +15% per 14-day period — differentiates 3d/7d/14d yields
- Match speed: 80% within 1-10s, 15% within 10-60s, 5% within 1-5min
- Status distribution: 20% PENDING_MATCH (was 10%) for order book depth

### Depth Chart
- `BUCKET_WIDTH`: 50 → 2 (2% APR buckets)
- APR range capped at 50% (was defaulting to 550%)

### ML/Quant Tab (was showing NO data)
- Backtest: handle dict format `{A: {default_rate, n_borrowers}}`
- Returns: values already percentages (6.064%), not fractions
- EDA: use `correlation` key (not `correlations`), show median
- Stress test: map `original_score`/`stressed_score`/`score_delta` fields

### Claude Agent
- New `/api/claude/insights` route — financial cash flow insights
- New `/api/claude/risk-explain` route — SHAP-based score narrative
- Prompt templates for financial insights + risk explanation

## Test plan
- [x] `pnpm build` passes
- [ ] Re-seed database (running, 10K trades)
- [ ] Verify depth chart shows 0-50% APR range
- [ ] Verify ML/Quant tabs load real data from Railway backend
- [ ] Verify bid APR shows 2-10% (not 0%)
- [ ] Verify yield curve shows differentiated APRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)