### PR TITLE
fix: harden backend lending flow

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,5 @@
+.claude/worktrees
+.turbo/cache
+quant_analysis/.venv
+quant_analysis/data
+apps/web/.next/dev

--- a/apps/web/src/app/(app)/lender/page.tsx
+++ b/apps/web/src/app/(app)/lender/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { LenderPageClient } from "@/components/lender/lender-page-client";
+import { LenderRealtimeWrapper } from "@/components/lender/lender-realtime-wrapper";
 
 export default async function LenderHomePage() {
   const supabase = await createClient();
@@ -226,7 +227,7 @@ export default async function LenderHomePage() {
     .sort((a, b) => a.new_due_date.localeCompare(b.new_due_date));
 
   return (
-    <>
+    <LenderRealtimeWrapper userId={user.id}>
       <LenderPageClient
         initialPot={
           pot
@@ -252,6 +253,6 @@ export default async function LenderHomePage() {
         usingMarketAvg={usingMarketAvg}
         upcomingRepayments={upcomingRepayments}
       />
-    </>
+    </LenderRealtimeWrapper>
   );
 }

--- a/apps/web/src/app/api/admin/match/route.ts
+++ b/apps/web/src/app/api/admin/match/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const maxDuration = 60;
+
+export async function POST(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json({ error: "CRON_SECRET not set" }, { status: 500 });
+  }
+
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  if (!body.trade_id) {
+    return NextResponse.json({ error: "trade_id required" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+
+  const { data, error } = await supabase.functions.invoke("match-trade", {
+    body: { trade_id: body.trade_id },
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Match failed", detail: error.message },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ success: true, match: data });
+}

--- a/apps/web/src/app/api/admin/settle/route.ts
+++ b/apps/web/src/app/api/admin/settle/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const maxDuration = 60;
+
+export async function POST(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json({ error: "CRON_SECRET not set" }, { status: 500 });
+  }
+
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const supabase = createAdminClient();
+
+  const { data, error } = await supabase.functions.invoke("settle-trade", {
+    body: body.trade_id ? { trade_id: body.trade_id } : {},
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Settlement failed", detail: error.message },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ success: true, settlement: data });
+}

--- a/apps/web/src/components/data/depth-chart.tsx
+++ b/apps/web/src/components/data/depth-chart.tsx
@@ -37,7 +37,7 @@ const GRADE_COLORS: Record<string, { fill: string; stroke: string; label: string
 
 const BID_COLOR = { fill: "rgba(59, 130, 246, 0.2)", stroke: "#3B82F6" };
 
-const BUCKET_WIDTH = 50; // 50% APR buckets
+const BUCKET_WIDTH = 5; // 5% APR buckets for granular visibility
 
 export function DepthChart({ pendingTrades, supplyOrders = [] }: DepthChartProps) {
   const [hoveredBucket, setHoveredBucket] = useState<{

--- a/apps/web/src/components/lender/lender-realtime-wrapper.tsx
+++ b/apps/web/src/components/lender/lender-realtime-wrapper.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useRealtime } from "@/lib/hooks/use-realtime";
+
+interface LenderRealtimeWrapperProps {
+  userId: string;
+  children: React.ReactNode;
+}
+
+export function LenderRealtimeWrapper({ userId, children }: LenderRealtimeWrapperProps) {
+  const router = useRouter();
+
+  // Refresh when lending pot balance changes (deposits, withdrawals, fee credits)
+  useRealtime("lending_pots", {
+    filter: `user_id=eq.${userId}`,
+    onUpdate: () => router.refresh(),
+  });
+
+  // Refresh when allocations change (new match, repayment, default)
+  useRealtime("allocations", {
+    filter: `lender_id=eq.${userId}`,
+    onInsert: () => router.refresh(),
+    onUpdate: () => router.refresh(),
+  });
+
+  return <>{children}</>;
+}

--- a/apps/web/src/lib/actions/trades.ts
+++ b/apps/web/src/lib/actions/trades.ts
@@ -108,23 +108,8 @@ export async function cancelTrade(tradeId: string) {
 
   if (!trade) throw new Error("Trade not found or cannot be cancelled");
 
-  // Release any RESERVED allocations back to lenders
-  const { releaseTradeAllocations } = await import("@/lib/allocations");
-  const { released, errors } = await releaseTradeAllocations(
-    admin,
-    tradeId,
-    "cancel-release",
-  );
-
-  if (errors.length > 0) {
-    console.error(`cancelTrade ${tradeId}: allocation release errors:`, errors);
-    throw new Error(
-      `Failed to release allocations: ${errors[0]}`,
-    );
-  }
-
-  // Cancel the trade with status guard to prevent race with match-trade
-  const { error, count } = await admin
+  // Cancel the trade FIRST with status guard — prevents race with match-trade
+  const { data: cancelled, error } = await admin
     .from("trades")
     .update({ status: "CANCELLED" })
     .eq("id", tradeId)
@@ -133,12 +118,23 @@ export async function cancelTrade(tradeId: string) {
 
   if (error) throw new Error(`Failed to cancel trade: ${error.message}`);
 
-  // If count is 0, the trade status changed between our check and update (race)
-  if (count === 0) {
-    console.warn(`cancelTrade ${tradeId}: trade status changed during cancel (possible race with match-trade)`);
+  if (!cancelled || cancelled.length === 0) {
+    throw new Error("Trade status changed (likely matched) — cannot cancel");
   }
 
-  // Log cancellation event AFTER trade is actually cancelled
+  // THEN release any RESERVED allocations back to lenders (trade is safely CANCELLED)
+  const { releaseTradeAllocations } = await import("@/lib/allocations");
+  const { released, errors: releaseErrors } = await releaseTradeAllocations(
+    admin,
+    tradeId,
+    "cancel-release",
+  );
+
+  if (releaseErrors.length > 0) {
+    console.error(`cancelTrade ${tradeId}: allocation release errors (trade already CANCELLED):`, releaseErrors);
+  }
+
+  // Log cancellation event
   await admin.from("flowzo_events").insert({
     event_type: "trade.cancelled",
     entity_type: "trade",


### PR DESCRIPTION
## Summary
- **cancelTrade race condition**: Status update to CANCELLED happens before allocation release, preventing race with match-trade Edge Function
- **fundTrade fee split + guards**: Self-dealing prevention, double-funding guard via existing allocation check, 80/20 platform fee split using FEE_CONFIG, sets platform_fee/lender_fee on trade record
- **Settlement atomicity**: All-or-nothing guard per trade across all 3 phases (disburse/repay/default) — trade status only updates if ALL allocations processed successfully
- **Immediate withdrawal**: queueWithdrawal() now instantly processes withdrawal when locked=0 instead of waiting for settlement cron
- **Admin endpoints**: POST /api/admin/settle and /api/admin/match for demo control (CRON_SECRET auth)
- **Lender Realtime**: LenderRealtimeWrapper subscribes to lending_pots + allocations changes for live UI updates
- **Depth chart**: BUCKET_WIDTH reduced from 50% to 5% for granular APR visibility
- **Seed data**: PENDING_MATCH trades get grade-appropriate APR spreads (A: 3-8%, B: 8-15%, C: 15-30%)

## Test plan
- [ ] `pnpm build` passes (verified locally)
- [ ] Cancel trade: create DRAFT → submit → cancel quickly — verify no orphaned allocations
- [ ] Fund trade: manually fund from lender page — verify `platform_fee`/`lender_fee` set on trade
- [ ] Manual settle: `curl -X POST /api/admin/settle -H "Authorization: Bearer $CRON_SECRET"` — verify MATCHED→LIVE and LIVE→REPAID transitions
- [ ] Withdrawal queue: lender with `locked=0` queues withdrawal — verify immediate withdrawal
- [ ] Re-seed and check depth chart shows data across APR buckets per grade

🤖 Generated with [Claude Code](https://claude.com/claude-code)