### PR TITLE
fix: no-match feedback, better explanation fallback

### DIFF
--- a/apps/web/src/app/(app)/borrower/page.tsx
+++ b/apps/web/src/app/(app)/borrower/page.tsx
@@ -210,7 +210,7 @@ export default async function BorrowerHomePage() {
   // Fetch active trades (PENDING_MATCH, MATCHED, or LIVE) for the borrower
   const { data: activeTrades } = await supabase
     .from("trades")
-    .select("id, amount, fee, original_due_date, new_due_date, shift_days, status, matched_at, live_at, obligations(name)")
+    .select("id, amount, fee, original_due_date, new_due_date, shift_days, status, matched_at, live_at, created_at, obligations(name)")
     .eq("borrower_id", user.id)
     .in("status", ["PENDING_MATCH", "MATCHED", "LIVE"])
     .order("new_due_date", { ascending: true });
@@ -228,6 +228,7 @@ export default async function BorrowerHomePage() {
       status: t.status as string,
       matched_at: t.matched_at,
       live_at: t.live_at,
+      created_at: t.created_at,
     };
   });
 

--- a/apps/web/src/components/borrower/active-shifts.tsx
+++ b/apps/web/src/components/borrower/active-shifts.tsx
@@ -11,6 +11,7 @@ interface ActiveShift {
   status: string;
   matched_at: string | null;
   live_at: string | null;
+  created_at?: string;
 }
 
 interface ActiveShiftsProps {
@@ -70,11 +71,21 @@ export function ActiveShifts({ shifts }: ActiveShiftsProps) {
                     <p className="text-xs text-text-secondary">{formatCurrency(shift.amount_pence)}</p>
                   </div>
                 </div>
-                {isPending ? (
-                  <span className="flex items-center gap-1 text-[10px] font-bold text-warning bg-warning/10 px-2 py-0.5 rounded-full">
-                    <span className="w-1.5 h-1.5 rounded-full bg-warning animate-pulse" />
-                    Finding lender
-                  </span>
+                {isPending ? (() => {
+                  const createdMs = shift.created_at ? new Date(shift.created_at).getTime() : 0;
+                  const waitingLong = createdMs > 0 && Date.now() - createdMs > 5 * 60 * 1000;
+                  return waitingLong ? (
+                    <span className="flex items-center gap-1 text-[10px] font-bold text-danger bg-danger/10 px-2 py-0.5 rounded-full">
+                      <span className="w-1.5 h-1.5 rounded-full bg-danger animate-pulse" />
+                      Taking longer than usual
+                    </span>
+                  ) : (
+                    <span className="flex items-center gap-1 text-[10px] font-bold text-warning bg-warning/10 px-2 py-0.5 rounded-full">
+                      <span className="w-1.5 h-1.5 rounded-full bg-warning animate-pulse" />
+                      Finding lender
+                    </span>
+                  );
+                })(
                 ) : isLive ? (
                   <span className="flex items-center gap-1 text-[10px] font-bold text-success bg-success/10 px-2 py-0.5 rounded-full">
                     <span className="w-1.5 h-1.5 rounded-full bg-success animate-pulse" />

--- a/apps/web/src/components/borrower/suggestion-card.tsx
+++ b/apps/web/src/components/borrower/suggestion-card.tsx
@@ -83,7 +83,7 @@ export function SuggestionCard({
   // Build a specific explanation fallback
   const explanation =
     proposal.explanation_text ??
-    `Your balance drops near ${formatDate(payload.original_date)}. Shifting to ${formatDate(payload.shifted_date)} keeps you in the green.`;
+    `Your ${payload.obligation_name} payment of ${formatCurrency(payload.amount_pence)} is due on ${formatDate(payload.original_date)}. Shifting it to ${formatDate(payload.shifted_date)} gives your balance more breathing room.`;
 
   async function handleAccept() {
     setIsAccepting(true);


### PR DESCRIPTION
## Summary
- **No-match feedback**: Active shifts now show "Taking longer than usual" (red badge) when a PENDING_MATCH trade has been waiting >5 minutes, instead of the generic "Finding lender" (from #86)
- **Explanation fallback**: Suggestion card explanation now names the specific bill and amount (e.g. "Your Electricity payment of £67.50 is due on 25 Feb...") instead of generic text (closes #28)

## Test plan
- [ ] Verify PENDING_MATCH trades <5 min show "Finding lender" (warning/yellow)
- [ ] Verify PENDING_MATCH trades >5 min show "Taking longer than usual" (danger/red)
- [ ] Verify suggestion cards without Claude explanation show bill-specific fallback text

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)