### PR TITLE
feat: Credit Risk tab + default history enforcement + pitch updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,16 @@ Member A (Pipeline) ──► Member B (needs real data for backtest + EDA)
 - Vercel redirect URI must be registered in TrueLayer Console: `https://<domain>/api/truelayer/callback`
 - Production: set `TRUELAYER_ENV=production` to switch to real banks (uk-ob-all uk-oauth-all)
 
+### Credit Risk System (Production-Level)
+- **Eligibility gate**: score >= 500 required (DB trigger `check_borrower_eligibility`)
+- **Credit limits enforced at DB level**: A=£500/5 trades, B=£200/3 trades, C=£75/1 trade
+- **Default history enforcement**: >20% default rate OR 2+ defaults in 30 days → blocked
+- **Continuous pricing**: `scoreAdjustedMultiplier()` interpolates within grade bands (A: 0.8-1.2x, B: 1.2-1.8x, C: 1.8-2.5x)
+- **Term premium**: +15% per 14-day period (3d/7d/14d differentiated)
+- **Income regularity scaling**: credit limits scaled by primary_bank_health_score (0.5-1.0x)
+- **Credit Risk tab** on /data page: score distribution, eligibility breakdown, rules display
+- **Profile columns**: credit_score, max_trade_amount, max_active_trades, eligible_to_borrow, last_scored_at
+
 ### Known Issues / Tech Debt
 - settle-trade processes allocations in a loop (not atomic) — if a step fails mid-loop, ledger/allocation mismatch possible
 - N+1 query pattern in match-trade lender scoring (fetches each lender's exposure individually)

--- a/apps/web/src/app/pitch/page.tsx
+++ b/apps/web/src/app/pitch/page.tsx
@@ -106,7 +106,7 @@ const slides = [
               step: "03",
               title: "Score & Propose",
               subtitle: "AI Decision Engine",
-              desc: "An A/B/C risk grade is assigned and APR calculated accordingly. Claude AI generates a plain-English bill-shift proposal.",
+              desc: "ML credit scoring (300-850) assigns risk grades. Continuous pricing adjusts APR by exact score. Borrowers below 500 are blocked. Claude AI explains each proposal.",
             },
           ].map(({ step, title, subtitle, desc }) => (
             <div key={title} className="bg-white/10 border border-white/20 rounded-2xl p-6 text-left">
@@ -193,7 +193,7 @@ const slides = [
           {[
             { label: "Borrower", desc: "Sees danger days on a calendar heatmap. Accepts a shift in one tap." },
             { label: "P2P Microlender", desc: " Displays orderbook to lenders. Deploys idle cash to a democratised P2P pool." },
-            { label: "Risk Engine", desc: "A/B/C grades drive fee pricing. Higher risk = higher return for lender." },
+            { label: "Risk Engine", desc: "ML credit scoring with eligibility gates, credit limits, and continuous score-adjusted pricing. Default history enforcement." },
             { label: "Settlement", desc: "Repayment on shifted date. Full double-entry ledger. Idempotent." },
           ].map(({ label, desc }) => (
             <div key={label} className="bg-white/10 border border-white/20 rounded-2xl p-5 text-left">
@@ -218,7 +218,7 @@ const slides = [
           <span className="text-coral">303K real loans.</span>
         </h1>
         <p className="text-xl text-white/70 max-w-2xl mx-auto mb-8 leading-relaxed">
-          Flowzo risk grades backtested on Home Credit Default Risk data. Grade A predicts defaults better than FICO alone.
+          Flowzo risk grades backtested on 303K Home Credit loans. ML credit scoring (300-850) with eligibility gates, continuous pricing, and default history enforcement.
         </p>
         <div className="grid grid-cols-2 gap-8 w-full max-w-md mx-auto mb-8">
           {[
@@ -235,7 +235,7 @@ const slides = [
           <div className="bg-coral/20 border border-coral/40 rounded-2xl px-6 py-4 text-center">
             <p className="text-coral font-extrabold text-sm uppercase tracking-wider">SIG Prize</p>
             <p className="text-white font-bold mt-1">Best Use of Data</p>
-            <p className="text-white/50 text-xs mt-1">Feature engineering · Backtesting · Explainability</p>
+            <p className="text-white/50 text-xs mt-1">Feature engineering · Credit scoring · Eligibility gates · Backtesting</p>
           </div>
           <div className="bg-white/10 border border-white/20 rounded-2xl px-6 py-4 text-center">
             <p className="text-white/60 font-extrabold text-sm uppercase tracking-wider">Monzo Track</p>

--- a/supabase/migrations/023_credit_risk_default_history.sql
+++ b/supabase/migrations/023_credit_risk_default_history.sql
@@ -1,0 +1,125 @@
+-- Migration 023: Enforce default history in eligibility + credit risk analytics views
+
+-- 1. Update eligibility trigger to check default history
+CREATE OR REPLACE FUNCTION check_borrower_eligibility()
+RETURNS TRIGGER AS $$
+DECLARE
+  p RECORD;
+  active_count integer;
+  default_rate numeric;
+  recent_defaults integer;
+BEGIN
+  SELECT credit_score, max_trade_amount, max_active_trades, eligible_to_borrow
+    INTO p FROM profiles WHERE id = NEW.borrower_id;
+
+  -- Must be eligible (scored and score >= 500)
+  IF NOT COALESCE(p.eligible_to_borrow, false) THEN
+    RAISE EXCEPTION 'Borrower not eligible: credit score below minimum threshold (500)';
+  END IF;
+
+  -- Check default history: >20% personal default rate → blocked
+  SELECT
+    COALESCE(
+      count(*) FILTER (WHERE status = 'DEFAULTED')::numeric /
+      NULLIF(count(*) FILTER (WHERE status IN ('REPAID', 'DEFAULTED')), 0),
+      0
+    ),
+    COALESCE(count(*) FILTER (WHERE status = 'DEFAULTED' AND defaulted_at > now() - interval '30 days'), 0)
+  INTO default_rate, recent_defaults
+  FROM trades
+  WHERE borrower_id = NEW.borrower_id AND status IN ('REPAID', 'DEFAULTED');
+
+  IF default_rate > 0.20 THEN
+    RAISE EXCEPTION 'Borrower blocked: personal default rate %.1f%% exceeds 20%% threshold', default_rate * 100;
+  END IF;
+
+  IF recent_defaults >= 2 THEN
+    RAISE EXCEPTION 'Borrower blocked: % defaults in last 30 days (max 1 allowed)', recent_defaults;
+  END IF;
+
+  -- Amount within credit limit
+  IF NEW.amount > COALESCE(p.max_trade_amount, 75) THEN
+    RAISE EXCEPTION 'Trade amount exceeds credit limit of %', p.max_trade_amount;
+  END IF;
+
+  -- Active trade count within limit
+  SELECT count(*) INTO active_count FROM trades
+    WHERE borrower_id = NEW.borrower_id
+      AND status IN ('PENDING_MATCH', 'MATCHED', 'LIVE');
+  IF active_count >= COALESCE(p.max_active_trades, 1) THEN
+    RAISE EXCEPTION 'Active trade limit reached: % of % allowed', active_count, p.max_active_trades;
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- 2. Credit risk analytics views for /data page
+
+-- Score distribution by grade
+CREATE OR REPLACE VIEW public.credit_score_distribution AS
+SELECT
+  risk_grade,
+  count(*) AS borrower_count,
+  ROUND(AVG(credit_score)::numeric) AS avg_score,
+  MIN(credit_score) AS min_score,
+  MAX(credit_score) AS max_score,
+  count(*) FILTER (WHERE eligible_to_borrow) AS eligible_count,
+  count(*) FILTER (WHERE NOT COALESCE(eligible_to_borrow, false)) AS ineligible_count,
+  ROUND(AVG(max_trade_amount)::numeric, 2) AS avg_credit_limit
+FROM profiles
+WHERE credit_score IS NOT NULL
+GROUP BY risk_grade
+ORDER BY risk_grade;
+
+GRANT SELECT ON public.credit_score_distribution TO authenticated;
+
+-- Credit utilization: how much of their limit are borrowers using
+CREATE OR REPLACE VIEW public.credit_utilization AS
+SELECT
+  p.risk_grade,
+  p.credit_score,
+  p.max_trade_amount AS credit_limit,
+  COALESCE(active.total_amount, 0) AS amount_in_use,
+  COALESCE(active.active_count, 0) AS active_trades,
+  p.max_active_trades AS trade_limit,
+  CASE WHEN p.max_trade_amount > 0
+    THEN ROUND((COALESCE(active.total_amount, 0) / p.max_trade_amount * 100)::numeric, 1)
+    ELSE 0
+  END AS utilization_pct,
+  bt.personal_default_rate,
+  bt.repaid_count,
+  bt.default_count
+FROM profiles p
+LEFT JOIN (
+  SELECT borrower_id, SUM(amount) AS total_amount, count(*) AS active_count
+  FROM trades WHERE status IN ('PENDING_MATCH', 'MATCHED', 'LIVE')
+  GROUP BY borrower_id
+) active ON active.borrower_id = p.id
+LEFT JOIN borrower_track_record bt ON bt.borrower_id = p.id
+WHERE p.credit_score IS NOT NULL
+  AND (p.role_preference = 'BORROWER_ONLY' OR p.role_preference = 'BOTH');
+
+GRANT SELECT ON public.credit_utilization TO authenticated;
+
+-- Eligibility summary (single-row aggregate)
+CREATE OR REPLACE VIEW public.eligibility_summary AS
+SELECT
+  count(*) AS total_borrowers,
+  count(*) FILTER (WHERE eligible_to_borrow) AS eligible,
+  count(*) FILTER (WHERE NOT COALESCE(eligible_to_borrow, false)) AS ineligible,
+  ROUND(
+    count(*) FILTER (WHERE eligible_to_borrow)::numeric / NULLIF(count(*), 0) * 100,
+    1
+  ) AS eligible_pct,
+  ROUND(AVG(credit_score)::numeric) AS avg_score,
+  MIN(credit_score) AS min_score,
+  MAX(credit_score) AS max_score,
+  count(*) FILTER (WHERE credit_score >= 700) AS grade_a_count,
+  count(*) FILTER (WHERE credit_score >= 600 AND credit_score < 700) AS grade_b_count,
+  count(*) FILTER (WHERE credit_score >= 500 AND credit_score < 600) AS grade_c_count,
+  count(*) FILTER (WHERE credit_score < 500) AS ineligible_score_count
+FROM profiles
+WHERE credit_score IS NOT NULL;
+
+GRANT SELECT ON public.eligibility_summary TO authenticated;


### PR DESCRIPTION
## Summary
New Credit Risk tab on /data page, default history enforcement in eligibility trigger, pitch deck updates.

## Changes

### New Credit Risk Tab (`/data` → "Credit Risk")
- **Eligibility Summary**: eligible/ineligible count, avg score, percentage
- **Grade Distribution**: horizontal bar chart showing A/B/C breakdown with percentages
- **Score Distribution Table**: per-grade borrower count, score range, avg score, avg credit limit, eligible count
- **Eligibility Rules**: visual display of all enforcement rules (score threshold, default rate, active trade limits)

### Default History Enforcement (Migration 023)
- Updated `check_borrower_eligibility()` trigger to check:
  - Personal default rate > 20% → trade blocked
  - 2+ defaults in last 30 days → trade blocked
- New analytics views: `credit_score_distribution`, `credit_utilization`, `eligibility_summary`

### Pitch Deck Updates
- "Score & Propose" slide: mentions ML credit scoring (300-850), continuous pricing, eligibility gates
- "Risk Engine" card: updated to mention credit limits, score-adjusted pricing, default history
- "Validation" slide: mentions eligibility gates and continuous pricing
- SIG prize card: added "Eligibility gates" to feature list

### CLAUDE.md
- Added full "Credit Risk System" section documenting eligibility rules, limits, pricing, and DB enforcement

## Test plan
- [x] `pnpm build` passes
- [x] Migration 023 applied to Supabase
- [ ] Credit Risk tab shows real data (score distribution, eligibility summary)
- [ ] Pitch deck updated text visible at /pitch

🤖 Generated with [Claude Code](https://claude.com/claude-code)