### PR TITLE
fix: reconcile PR #87 — settlement atomicity, race fixes, admin tools

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,5 @@
+.claude/worktrees
+.turbo/cache
+quant_analysis/.venv
+quant_analysis/data
+apps/web/.next/dev

--- a/apps/web/src/app/(app)/lender/page.tsx
+++ b/apps/web/src/app/(app)/lender/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
 import { LenderPageClient } from "@/components/lender/lender-page-client";
+import { LenderRealtimeWrapper } from "@/components/lender/lender-realtime-wrapper";
 
 export default async function LenderHomePage() {
   const supabase = await createClient();
@@ -226,7 +227,7 @@ export default async function LenderHomePage() {
     .sort((a, b) => a.new_due_date.localeCompare(b.new_due_date));
 
   return (
-    <>
+    <LenderRealtimeWrapper userId={user.id}>
       <LenderPageClient
         initialPot={
           pot
@@ -252,6 +253,6 @@ export default async function LenderHomePage() {
         usingMarketAvg={usingMarketAvg}
         upcomingRepayments={upcomingRepayments}
       />
-    </>
+    </LenderRealtimeWrapper>
   );
 }

--- a/apps/web/src/app/api/admin/match/route.ts
+++ b/apps/web/src/app/api/admin/match/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const maxDuration = 60;
+
+export async function POST(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json({ error: "CRON_SECRET not set" }, { status: 500 });
+  }
+
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  if (!body.trade_id) {
+    return NextResponse.json({ error: "trade_id required" }, { status: 400 });
+  }
+
+  const supabase = createAdminClient();
+
+  const { data, error } = await supabase.functions.invoke("match-trade", {
+    body: { trade_id: body.trade_id },
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Match failed", detail: error.message },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ success: true, match: data });
+}

--- a/apps/web/src/app/api/admin/settle/route.ts
+++ b/apps/web/src/app/api/admin/settle/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+
+export const maxDuration = 60;
+
+export async function POST(request: Request) {
+  const cronSecret = process.env.CRON_SECRET;
+  if (!cronSecret) {
+    return NextResponse.json({ error: "CRON_SECRET not set" }, { status: 500 });
+  }
+
+  const authHeader = request.headers.get("authorization");
+  if (authHeader !== `Bearer ${cronSecret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const supabase = createAdminClient();
+
+  const { data, error } = await supabase.functions.invoke("settle-trade", {
+    body: body.trade_id ? { trade_id: body.trade_id } : {},
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Settlement failed", detail: error.message },
+      { status: 502 },
+    );
+  }
+
+  return NextResponse.json({ success: true, settlement: data });
+}

--- a/apps/web/src/components/lender/lender-realtime-wrapper.tsx
+++ b/apps/web/src/components/lender/lender-realtime-wrapper.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useRealtime } from "@/lib/hooks/use-realtime";
+
+interface LenderRealtimeWrapperProps {
+  userId: string;
+  children: React.ReactNode;
+}
+
+export function LenderRealtimeWrapper({ userId, children }: LenderRealtimeWrapperProps) {
+  const router = useRouter();
+
+  // Refresh when lending pot balance changes (deposits, withdrawals, fee credits)
+  useRealtime("lending_pots", {
+    filter: `user_id=eq.${userId}`,
+    onUpdate: () => router.refresh(),
+  });
+
+  // Refresh when allocations change (new match, repayment, default)
+  useRealtime("allocations", {
+    filter: `lender_id=eq.${userId}`,
+    onInsert: () => router.refresh(),
+    onUpdate: () => router.refresh(),
+  });
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
## Summary
Reconciled and merged changes from PR #87 (`feat/backend-lending-hardening`) which had merge conflicts with main. All improvements applied on top of the current main branch.

## Changes From PR #87 (Reconciled)

### Settlement Atomicity (settle-trade Edge Function)
- All-or-nothing guard: trade status only updates if ALL allocations processed
- `allAllocsProcessed` / `allAllocsRepaid` / `allAllocsDefaulted` flags per phase
- Failed mid-loop → trade stays in current status, retried on next cron run

### cancelTrade Race Fix (trades.ts)
- Cancel status updated FIRST (prevents race with match-trade)
- Allocations released AFTER trade is safely CANCELLED
- If status already changed (matched), throws clear error

### fundTrade Hardening (lending.ts)
- Self-dealing prevention: cannot fund your own trade
- Double-funding guard: checks existing allocations before creating new
- 80/20 fee split: sets platform_fee/lender_fee on trade

### Admin Endpoints (NEW)
- `POST /api/admin/settle` — trigger settlement for demo control
- `POST /api/admin/match` — trigger matching for specific trade
- Both require `CRON_SECRET` auth header

### Lender Realtime (NEW)
- `LenderRealtimeWrapper` subscribes to `lending_pots` + `allocations` changes
- Lender page auto-refreshes on balance changes, new matches, repayments

### .vercelignore
- Excludes worktrees, turbo cache, Python venv from Vercel deployments

## Conflicts Resolved
- `depth-chart.tsx`: kept our BUCKET_WIDTH=2 (PR #87 had 5)
- `seed.ts`: kept our 10K trades + continuous pricing (PR #87 had APR spreads for PENDING_MATCH)
- `trades.ts`: merged eligibility check with cancel race fix

Closes #87

## Test plan
- [x] `pnpm build` passes
- [ ] Cancel trade race: create → submit → cancel quickly
- [ ] Admin settle: `curl -X POST /api/admin/settle -H "Authorization: Bearer $CRON_SECRET"`
- [ ] Lender realtime: verify page refreshes on balance change

🤖 Generated with [Claude Code](https://claude.com/claude-code)